### PR TITLE
fix: Correct GitHub Pages deployment links and homepage

### DIFF
--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -1,0 +1,5 @@
+# Willkommen bei Emotions for Engineers
+
+Dies ist das zentrale Repository für die Kursinhalte.
+
+Bitte verwenden Sie die Navigation, um die Kursmaterialien zu finden.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,5 @@
+# Welcome to Emotions for Engineers
+
+This is the central repository for the course content.
+
+Please use the navigation to find the course materials.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: My Awesome Course
-repo_url: https://github.com/user/repo-name # Replace with your repo URL
+site_url: https://florindottudosedotcom.github.io/emotions-for-engineers/
+repo_url: https://github.com/florindottudosedotcom/emotions-for-engineers
 
 theme:
   name: material


### PR DESCRIPTION
This commit resolves issues with the deployed GitHub Pages site.

The main problems were:
1. All asset and page links were broken (404 errors) because they did not include the repository name in the path.
2. The root of the website showed a 404 error because no homepage was defined.

The following changes were made to fix this:
- The `site_url` was added to `mkdocs.yml` to ensure all generated links are correctly prefixed for GitHub Pages.
- The placeholder `repo_url` was updated to the correct repository URL.
- `index.md` files were created for both the English and German languages to serve as homepages.