### PR TITLE
feat: Add dynamic homepage generation script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: pip install -r requirements.txt
+      - name: Generate course index page
+        run: python scripts/build_index.py
       - name: Build the MkDocs site
         run: mkdocs build
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # MkDocs
 site/
+docs/index.md
 
 # Python
 venv/

--- a/README.md
+++ b/README.md
@@ -23,22 +23,22 @@ The repository is organized to support multiple courses and multiple languages i
 ```
 .
 ├── docs/
-│   ├── en/                  # English language content
+│   ├── en/
 │   │   └── course-example/
-│   │       ├── assets/
-│   │       │   └── placeholder.png
-│   │       ├── 01-introduction.md
-│   │       └── 02-advanced-topics.md
-│   └── de/                  # German language content
-│       └── course-example/
-│           └── 01-introduction.md
-├── mkdocs.yml             # Main configuration file for the site
-└── requirements.txt       # Python dependencies
+│   │       ├── index.md     # Course homepage with metadata
+│   │       └── ...
+│   └── de/
+│       └── ...
+├── scripts/
+│   └── build_index.py       # Script to generate the main homepage
+├── .gitignore
+├── mkdocs.yml
+└── requirements.txt
 ```
 
-- **`docs/`**: This is the heart of your repository, containing all source content.
-- **`docs/<lang>/`**: Each language gets its own sub-folder (e.g., `en` for English, `de` for German).
-- **`docs/<lang>/<course-name>/`**: Inside each language folder, create a folder for each course.
+- **`docs/`**: Contains all source content. The main `index.md` in this folder is auto-generated and should not be edited manually.
+- **`docs/<lang>/<course-name>/`**: Each course has its own folder within a language.
+- **`scripts/`**: Contains helper scripts, like the one to build the main homepage.
 
 ## Getting Started
 
@@ -63,13 +63,18 @@ To work with this repository on your local machine, you'll need Python installed
 
 ## Local Development
 
-To preview your website as you make changes, run the MkDocs live-reloading server.
+To preview your website as you make changes, you first need to generate the main homepage, then start the live-reloading server.
 
-```bash
-mkdocs serve
-```
+1.  **Generate the Homepage:**
+    ```bash
+    python scripts/build_index.py
+    ```
+2.  **Run the Server:**
+    ```bash
+    mkdocs serve
+    ```
 
-This will start a local web server, typically at `http://127.0.0.1:8000`, where you can preview your site. The `mkdocs-static-i18n` plugin handles serving all languages at once under different paths (e.g., `/` for English, `/de/` for German), so the single `mkdocs serve` command is sufficient. The website will automatically refresh whenever you save a file.
+This will start a local web server, typically at `http://127.0.0.1:8000`. If you add a new course, you will need to re-run the `build_index.py` script to see it on the main homepage.
 
 ## Managing Content
 
@@ -77,8 +82,17 @@ This will start a local web server, typically at `http://127.0.0.1:8000`, where 
 
 1.  Decide on a short, descriptive name for your course folder (e.g., `new-course`).
 2.  Create a new directory for the course inside the default language folder: `docs/en/new-course`.
-3.  Add your Markdown (`.md`) files to this new directory.
-4.  There is no need to manually update the navigation; the site will automatically discover the new files.
+3.  **Create a course homepage:** Add an `index.md` file inside your new course directory (`docs/en/new-course/index.md`).
+4.  **Add metadata:** At the top of this new `index.md`, add a "front matter" block with a description. This description will be shown on the main site landing page.
+    ```yaml
+    ---
+    description: "A short, exciting description for your new course."
+    ---
+
+    # Welcome to the New Course
+    ...
+    ```
+5.  Add your other chapter Markdown (`.md`) files to the course directory.
 
 ### Adding a New Chapter
 

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -1,5 +1,0 @@
-# Willkommen bei Emotions for Engineers
-
-Dies ist das zentrale Repository für die Kursinhalte.
-
-Bitte verwenden Sie die Navigation, um die Kursmaterialien zu finden.

--- a/docs/en/course-example/index.md
+++ b/docs/en/course-example/index.md
@@ -1,0 +1,9 @@
+---
+description: An example course to demonstrate the structure of this repository and the features of the generated website.
+---
+
+# Welcome to Emotions for Engineers
+
+This is the homepage for the "Emotions for Engineers" course.
+
+Please use the navigation to browse the chapters.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,5 +1,0 @@
-# Welcome to Emotions for Engineers
-
-This is the central repository for the course content.
-
-Please use the navigation to find the course materials.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs
 mkdocs-material
 mkdocs-static-i18n
+python-frontmatter

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,0 +1,64 @@
+import os
+import frontmatter
+from pathlib import Path
+
+def main():
+    """
+    Scans for courses and generates a root index.md file with a card grid.
+    """
+    docs_dir = Path("docs")
+    en_dir = docs_dir / "en"
+    index_md_path = docs_dir / "index.md"
+
+    if not en_dir.is_dir():
+        print(f"Directory not found: {en_dir}")
+        return
+
+    courses = []
+    for course_dir in en_dir.iterdir():
+        if course_dir.is_dir():
+            course_index_path = course_dir / "index.md"
+            if course_index_path.is_file():
+                try:
+                    post = frontmatter.load(course_index_path)
+                    description = post.get("description", "No description available.")
+
+                    # Generate a clean course title from the directory name
+                    title = course_dir.name.replace("-", " ").replace("_", " ").title()
+
+                    courses.append({
+                        "title": title,
+                        "description": description,
+                        "path": f"en/{course_dir.name}/"
+                    })
+                except Exception as e:
+                    print(f"Could not process {course_index_path}: {e}")
+
+    # Sort courses alphabetically by title
+    courses.sort(key=lambda x: x["title"])
+
+    # Generate the content for the root index.md file
+    content = "# Available Courses\n\n"
+    content += "Here is a list of all available courses. Please select one to get started.\n\n"
+
+    if not courses:
+        content += "No courses are available yet. Please check back later!"
+    else:
+        content += '<div class="grid cards" markdown>\n\n'
+        for course in courses:
+            content += f'-   [___{course["title"]}___]({course["path"]}){{.card-title}}\n\n'
+            content += f'    ---\n'
+            content += f'    {course["description"]}\n\n'
+            content += f'    [:octicons-arrow-right-24: Go to course]({course["path"]})\n\n'
+        content += '</div>\n'
+
+    # Write the generated content to the root index.md
+    try:
+        with open(index_md_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        print(f"Successfully generated {index_md_path} with {len(courses)} courses.")
+    except Exception as e:
+        print(f"Could not write to {index_md_path}: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces an automated system for generating a dynamic main homepage that displays an overview of all available courses.

This solves the issue of the site's root URL returning a 404 error and provides a much better user experience.

Key changes:
- A new Python script (`scripts/build_index.py`) scans the `docs/en/` directory for courses.
- The script reads metadata (a `description`) from the front matter of each course's `index.md` file.
- It then generates a new root `docs/index.md` containing a card-based grid of the available courses.
- The GitHub Actions workflow has been updated to run this script before the build, ensuring the homepage is always up-to-date on deployment.
- The README has been updated with instructions for the new workflow.
- Dependencies (`python-frontmatter`) and `.gitignore` have been updated accordingly.