### PR TITLE
fix: Enable markdown extensions for card layout

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,3 +36,7 @@ plugins:
         - locale: de
           name: Deutsch
           build: true
+
+markdown_extensions:
+  - attr_list
+  - md_in_html


### PR DESCRIPTION
This commit fixes the rendering of the dynamically generated homepage. The page was displaying raw markdown for the card grid instead of the rendered visual cards.

This was caused by missing configuration in `mkdocs.yml`. The `attr_list` and `md_in_html` extensions, which are required by the Material for MkDocs theme to process the card syntax, were not enabled.

This commit adds the necessary `markdown_extensions` to the `mkdocs.yml` file, which resolves the rendering issue. The homepage should now display the course overview in a tiled grid layout as intended.