### PR TITLE
fix: Polish UI by enabling icons and removing nav tabs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,6 @@ theme:
   name: material
   language: en # Sets the default language for the site
   features:
-    - navigation.tabs
     - navigation.sections
     - toc.integrate
     - navigation.top
@@ -40,3 +39,6 @@ plugins:
 markdown_extensions:
   - attr_list
   - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
This commit applies final UI polish based on user feedback.

- Enables the `pymdownx.emoji` markdown extension in `mkdocs.yml`. This allows icon shortcodes (e.g., `:octicons-arrow-right-24:`) to be rendered correctly as SVG icons, fixing an issue on the main landing page.
- Removes the `navigation.tabs` feature from the theme configuration in `mkdocs.yml`. This removes the redundant top-level language navigation tabs, making the language switcher dropdown in the header the sole method for language selection, as requested.