### PR TITLE
Fix: Language switcher generates incorrect course URLs

### DIFF
--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -9,11 +9,11 @@ Hier ist eine Liste aller verfügbaren Kurse. Bitte wählen Sie einen aus, um zu
 
 <div class="grid cards" markdown>
 
--   [___Course Example___](../de/course-example/){.card-title}
+-   [___Course Example___](course-example/){.card-title}
 
     ---
     Ein Beispielkurs, um die Struktur dieses Repositories und die Funktionen der generierten Website zu demonstrieren.
 
-    [:octicons-arrow-right-24: Zum Kurs](../de/course-example/)
+    [:octicons-arrow-right-24: Zum Kurs](course-example/)
 
 </div>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -9,11 +9,11 @@ Here is a list of all available courses. Please select one to get started.
 
 <div class="grid cards" markdown>
 
--   [___Course Example___](../en/course-example/){.card-title}
+-   [___Course Example___](course-example/){.card-title}
 
     ---
     An example course to demonstrate the structure of this repository and the features of the generated website.
 
-    [:octicons-arrow-right-24: Go to course](../en/course-example/)
+    [:octicons-arrow-right-24: Go to course](course-example/)
 
 </div>

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -26,7 +26,7 @@ def generate_index_for_language(lang_dir, translations):
                     courses.append({
                         "title": title,
                         "description": description,
-                        "path": f"../{lang_code}/{course_dir.name}/"
+                        "path": f"{course_dir.name}/"
                     })
                 except Exception as e:
                     print(f"Could not process {course_index_path}: {e}")


### PR DESCRIPTION
This commit fixes a bug where the language switcher would generate incorrect URLs for courses when switching languages. The issue was caused by incorrect relative path generation in the `build_index.py` script.

The path generation has been corrected to use a simpler relative path from within the language-specific index files. This ensures that the links to courses are resolved correctly by `mkdocs`.

This commit builds upon the previous refactoring of the `build_index.py` script to support multiple languages.