### PR TITLE
Fix: Use absolute paths for course links

### DIFF
--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -9,11 +9,11 @@ Hier ist eine Liste aller verfügbaren Kurse. Bitte wählen Sie einen aus, um zu
 
 <div class="grid cards" markdown>
 
--   [___Course Example___](course-example/){.card-title}
+-   [___Course Example___](/de/course-example/){.card-title}
 
     ---
     Ein Beispielkurs, um die Struktur dieses Repositories und die Funktionen der generierten Website zu demonstrieren.
 
-    [:octicons-arrow-right-24: Zum Kurs](course-example/)
+    [:octicons-arrow-right-24: Zum Kurs](/de/course-example/)
 
 </div>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -9,11 +9,11 @@ Here is a list of all available courses. Please select one to get started.
 
 <div class="grid cards" markdown>
 
--   [___Course Example___](course-example/){.card-title}
+-   [___Course Example___](/en/course-example/){.card-title}
 
     ---
     An example course to demonstrate the structure of this repository and the features of the generated website.
 
-    [:octicons-arrow-right-24: Go to course](course-example/)
+    [:octicons-arrow-right-24: Go to course](/en/course-example/)
 
 </div>

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -26,7 +26,7 @@ def generate_index_for_language(lang_dir, translations):
                     courses.append({
                         "title": title,
                         "description": description,
-                        "path": f"{course_dir.name}/"
+                        "path": f"/{lang_code}/{course_dir.name}/"
                     })
                 except Exception as e:
                     print(f"Could not process {course_index_path}: {e}")


### PR DESCRIPTION
This commit provides a definitive fix for the language switcher bug where incorrect URLs were being generated for courses. The issue was caused by ambiguous relative path resolution.

The `build_index.py` script has been updated to generate absolute paths for all course links (e.g., `/en/course-example/`). This ensures that the links are always resolved correctly from the site root, regardless of the current page's path.

This change should finally resolve the persistent issue with the language switcher.