### PR TITLE
feat: Add local course creator tool

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Universal Course Creator</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 2rem auto; padding: 0 1rem; background-color: #f9f9f9; }
+        h1, h2, h3 { color: #2c3e50; }
+        .container { background-color: #fff; padding: 2rem; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1); }
+        .instructions { background-color: #eaf5ff; border-left: 4px solid #3498db; padding: 1rem; margin-bottom: 2rem; border-radius: 4px; }
+        label { display: block; margin-bottom: 0.5rem; font-weight: bold; }
+        input[type="text"], textarea { width: 100%; padding: 0.75rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; margin-bottom: 1rem; }
+        textarea { min-height: 100px; resize: vertical; }
+        fieldset { border: 1px solid #ccc; border-radius: 4px; padding: 1rem; margin-bottom: 1rem; }
+        legend { font-weight: bold; padding: 0 0.5rem; }
+        .lang-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; }
+        .lang-item { display: flex; align-items: center; }
+        input[type="checkbox"] { margin-right: 0.5rem; }
+        .chapter { border: 1px solid #ddd; padding: 1rem; border-radius: 4px; margin-bottom: 1rem; background-color: #fafafa; }
+        .chapter-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+        .btn { padding: 0.75rem 1.5rem; border: none; border-radius: 4px; color: #fff; cursor: pointer; font-size: 1rem; }
+        .btn-primary { background-color: #3498db; }
+        .btn-primary:hover { background-color: #2980b9; }
+        .btn-secondary { background-color: #2ecc71; }
+        .btn-secondary:hover { background-color: #27ae60; }
+        .btn-danger { background-color: #e74c3c; padding: 0.25rem 0.75rem; }
+        .btn-danger:hover { background-color: #c0392b; }
+        #download-section { margin-top: 2rem; padding: 1rem; background-color: #f0fff4; border: 1px solid #2ecc71; border-radius: 4px; display: none; }
+    </style>
+</head>
+<body>
+
+    <div class="container">
+        <h1>Universal Course Creator</h1>
+
+        <div class="instructions">
+            <h3>How to Use This Tool</h3>
+            <ol>
+                <li>Fill out the form below with your course details. English is the primary language.</li>
+                <li>Click "Generate Course Files". This will create a <strong>.zip</strong> file containing all the necessary folders and files for your new course.</li>
+                <li>Extract the contents of the downloaded .zip file into the <strong>`docs/`</strong> directory of your project.</li>
+                <li>(Optional) If you selected new languages, update your <strong>`mkdocs.yml`</strong> file using the tool at the bottom of the page.</li>
+                <li>Run <code>python scripts/build_index.py</code> and then <code>mkdocs serve</code> in your terminal to see your new course.</li>
+            </ol>
+        </div>
+
+        <form id="course-form">
+            <h2>Course Details</h2>
+            <label for="course-name">Course Name</label>
+            <input type="text" id="course-name" placeholder="e.g., Introduction to Python" required>
+
+            <label for="course-desc">Course Description (for main landing page)</label>
+            <textarea id="course-desc" placeholder="A short, exciting description for your new course." required></textarea>
+
+            <fieldset>
+                <legend>Course Languages</legend>
+                <div class="lang-grid">
+                    <div class="lang-item"><input type="checkbox" id="lang-en" value="en" data-name="English" checked> <label for="lang-en">English</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-zh" value="zh" data-name="Mandarin Chinese"> <label for="lang-zh">Mandarin Chinese</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-es" value="es" data-name="Spanish"> <label for="lang-es">Spanish</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-hi" value="hi" data-name="Hindi"> <label for="lang-hi">Hindi</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-pt" value="pt" data-name="Portuguese"> <label for="lang-pt">Portuguese</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-ru" value="ru" data-name="Russian"> <label for="lang-ru">Russian</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-ja" value="ja" data-name="Japanese"> <label for="lang-ja">Japanese</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-fr" value="fr" data-name="French"> <label for="lang-fr">French</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-it" value="it" data-name="Italian"> <label for="lang-it">Italian</label></div>
+                    <div class="lang-item"><input type="checkbox" id="lang-ro" value="ro" data-name="Romanian"> <label for="lang-ro">Romanian</label></div>
+                </div>
+            </fieldset>
+
+            <h2>Chapters</h2>
+            <div id="chapters-container">
+                <!-- Chapters will be dynamically added here -->
+            </div>
+            <button type="button" id="add-chapter" class="btn btn-secondary">Add Chapter</button>
+
+            <hr style="margin: 2rem 0;">
+
+            <button type="submit" class="btn btn-primary">Generate Course Files</button>
+        </form>
+
+        <div id="download-section">
+            <h3>Downloads</h3>
+            <p>Your files have been generated. Download them below.</p>
+            <a id="download-zip" class="btn btn-primary">Download Course Files (.zip)</a>
+        </div>
+
+        <hr style="margin: 2rem 0;">
+
+        <h2>`mkdocs.yml` Updater</h2>
+        <div class="instructions">
+            <p>If you selected a language that is not already in your `mkdocs.yml` file, use this tool to update it. This will ensure the language switcher appears correctly on your site.</p>
+        </div>
+        <label for="mkdocs-upload">1. Upload your current `mkdocs.yml` file:</label>
+        <input type="file" id="mkdocs-upload" accept=".yml,.yaml">
+        <br><br>
+        <button id="update-mkdocs" class="btn btn-secondary" disabled>2. Generate Updated `mkdocs.yml`</button>
+        <div id="mkdocs-download-section" style="display: none; margin-top: 1rem;">
+             <a id="download-mkdocs" class="btn btn-primary">Download Updated `mkdocs.yml`</a>
+        </div>
+    </div>
+
+    <!-- JS Libraries -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
+
+    <!-- Main Application Logic -->
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const courseForm = document.getElementById('course-form');
+            const chaptersContainer = document.getElementById('chapters-container');
+            const addChapterBtn = document.getElementById('add-chapter');
+            const downloadSection = document.getElementById('download-section');
+            const downloadZipLink = document.getElementById('download-zip');
+
+            let chapterCount = 0;
+
+            const slugify = (text) => {
+                return text.toString().toLowerCase()
+                    .replace(/\s+/g, '-')           // Replace spaces with -
+                    .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
+                    .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+                    .replace(/^-+/, '')             // Trim - from start of text
+                    .replace(/-+$/, '');            // Trim - from end of text
+            };
+
+            const addChapter = () => {
+                chapterCount++;
+                const chapterId = chapterCount;
+                const chapterDiv = document.createElement('div');
+                chapterDiv.className = 'chapter';
+                chapterDiv.id = `chapter-${chapterId}`;
+                chapterDiv.innerHTML = `
+                    <div class="chapter-header">
+                        <h3>Chapter ${chapterId}</h3>
+                        <button type="button" class="btn btn-danger remove-chapter-btn" data-chapter-id="${chapterId}">Remove</button>
+                    </div>
+                    <label for="chapter-title-${chapterId}">Chapter Title</label>
+                    <input type="text" id="chapter-title-${chapterId}" class="chapter-title" placeholder="e.g., Getting Started" required>
+                    <label for="chapter-content-${chapterId}">Chapter Content (in Markdown)</label>
+                    <textarea id="chapter-content-${chapterId}" class="chapter-content" placeholder="Write your chapter content here..."></textarea>
+                `;
+                chaptersContainer.appendChild(chapterDiv);
+
+                chapterDiv.querySelector('.remove-chapter-btn').addEventListener('click', () => {
+                    document.getElementById(`chapter-${chapterId}`).remove();
+                });
+            };
+
+            addChapterBtn.addEventListener('click', addChapter);
+
+            courseForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+
+                const courseName = document.getElementById('course-name').value;
+                const courseDesc = document.getElementById('course-desc').value;
+                const selectedLangs = Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+
+                if (selectedLangs.length === 0) {
+                    alert('Please select at least one language.');
+                    return;
+                }
+
+                const courseSlug = slugify(courseName);
+                if (!courseSlug) {
+                    alert('Please enter a valid course name.');
+                    return;
+                }
+
+                const zip = new JSZip();
+                const courseFolder = zip.folder(courseSlug);
+
+                const chapters = [];
+                document.querySelectorAll('.chapter').forEach((chapterDiv, index) => {
+                    const title = chapterDiv.querySelector('.chapter-title').value;
+                    const content = chapterDiv.querySelector('.chapter-content').value;
+                    const chapterSlug = slugify(title);
+                    const chapterNumber = String(index + 1).padStart(2, '0');
+                    chapters.push({ title, content, slug: chapterSlug, number: chapterNumber });
+                });
+
+                if (chapters.length === 0) {
+                    alert('Please add at least one chapter.');
+                    return;
+                }
+
+                const primaryLang = 'en';
+                const primaryLangData = {
+                    index: `---\ndescription: ${courseDesc}\n---\n\n# ${courseName}`,
+                    chapters: chapters.map(ch => ({
+                        filename: `${ch.number}-${ch.slug}.${primaryLang}.md`,
+                        content: `# ${ch.title}\n\n${ch.content}`
+                    }))
+                };
+
+                // Create files for all selected languages
+                for (const lang of selectedLangs) {
+                    // For now, we use English content for all languages as per the plan (Option A)
+                    // The user will translate these files manually.
+                    const indexContent = `---\ndescription: ${courseDesc}\n---\n\n# ${courseName}\n\n<!-- TODO: Translate this page to ${lang} -->`;
+                    courseFolder.file(`index.${lang}.md`, indexContent);
+
+                    for (const chapter of chapters) {
+                        const chapterFilename = `${chapter.number}-${chapter.slug}.${lang}.md`;
+                        const chapterContent = `# ${chapter.title}\n\n${chapter.content}\n\n<!-- TODO: Translate this chapter to ${lang} -->`;
+                        courseFolder.file(chapterFilename, chapterContent);
+                    }
+
+                    // Create empty assets folder
+                    courseFolder.folder('assets');
+                }
+
+                const zipBlob = await zip.generateAsync({ type: 'blob' });
+                downloadZipLink.href = URL.createObjectURL(zipBlob);
+                downloadZipLink.download = `${courseSlug}.zip`;
+                downloadSection.style.display = 'block';
+
+                // Also create an empty assets folder in each course
+                const assetsFolder = courseFolder.folder('assets');
+                assetsFolder.file('.gitkeep', '');
+
+
+                alert('Success! Your course files have been packaged. Click the download link that has appeared.');
+            });
+
+            // Add the first chapter on page load
+            addChapter();
+
+            // MKDocs Updater Logic
+            const mkdocsUpload = document.getElementById('mkdocs-upload');
+            const updateMkdocsBtn = document.getElementById('update-mkdocs');
+            const mkdocsDownloadSection = document.getElementById('mkdocs-download-section');
+            const downloadMkdocsLink = document.getElementById('download-mkdocs');
+            let mkdocsContent = null;
+
+            mkdocsUpload.addEventListener('change', (e) => {
+                const file = e.target.files[0];
+                if (file) {
+                    const reader = new FileReader();
+                    reader.onload = (event) => {
+                        mkdocsContent = event.target.result;
+                        updateMkdocsBtn.disabled = false;
+                    };
+                    reader.readAsText(file);
+                }
+            });
+
+            updateMkdocsBtn.addEventListener('click', () => {
+                if (!mkdocsContent) {
+                    alert('Please upload your mkdocs.yml file first.');
+                    return;
+                }
+
+                try {
+                    const config = jsyaml.load(mkdocsContent);
+
+                    const selectedLangs = Array.from(document.querySelectorAll('input[type="checkbox"]:checked'));
+                    const newLangs = selectedLangs.map(cb => ({
+                        locale: cb.value,
+                        name: cb.dataset.name
+                    }));
+
+                    // Ensure sections exist
+                    if (!config.extra) config.extra = {};
+                    if (!config.extra.alternate) config.extra.alternate = [];
+                    if (!config.plugins) config.plugins = [];
+
+                    let i18nPlugin = config.plugins.find(p => p.i18n);
+                    if (!i18nPlugin) {
+                        i18nPlugin = { i18n: { languages: [] } };
+                        config.plugins.push(i18nPlugin);
+                    }
+                    if (!i18nPlugin.i18n.languages) i18nPlugin.i18n.languages = [];
+
+                    const existingLocales = new Set(i18nPlugin.i18n.languages.map(l => l.locale));
+
+                    let updated = false;
+                    for (const lang of newLangs) {
+                        if (!existingLocales.has(lang.locale)) {
+                            updated = true;
+                            // Add to plugins.i18n.languages
+                            const newLangPluginEntry = { locale: lang.locale, name: lang.name };
+                            if (lang.locale === 'en') {
+                                newLangPluginEntry.default = true;
+                            }
+                            i18nPlugin.i18n.languages.push(newLangPluginEntry);
+
+                            // Add to extra.alternate
+                            const newAlternateEntry = { name: lang.name, lang: lang.locale };
+                            newAlternateEntry.link = lang.locale === 'en' ? '/' : `/${lang.locale}/`;
+                            config.extra.alternate.push(newAlternateEntry);
+                        }
+                    }
+
+                    if (!updated) {
+                        alert('No new languages to add. Your mkdocs.yml file is already up to date with the selected languages.');
+                        return;
+                    }
+
+                    // Sort languages to be neat, default 'en' first
+                    i18nPlugin.i18n.languages.sort((a, b) => {
+                        if (a.default) return -1;
+                        if (b.default) return 1;
+                        return a.locale.localeCompare(b.locale);
+                    });
+                    config.extra.alternate.sort((a, b) => {
+                         if (a.lang === 'en') return -1;
+                         if (b.lang === 'en') return 1;
+                         return a.lang.localeCompare(b.lang);
+                    });
+
+
+                    const newMkdocsContent = jsyaml.dump(config, { indent: 2 });
+                    const blob = new Blob([newMkdocsContent], { type: 'text/yaml' });
+                    downloadMkdocsLink.href = URL.createObjectURL(blob);
+                    downloadMkdocsLink.download = 'mkdocs.updated.yml';
+                    mkdocsDownloadSection.style.display = 'block';
+
+                    alert('Success! Your mkdocs.yml has been updated. Download the new file and replace your old one.');
+
+                } catch (error) {
+                    console.error('Error processing mkdocs.yml:', error);
+                    alert(`An error occurred: ${error.message}. Please check the console for details.`);
+                }
+            });
+        });
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new self-contained HTML file, `course-creator.html`, which serves as a local tool for generating new course materials.

The tool provides a user-friendly web interface with the following features:
- Input fields for course name and description.
- Checkboxes to select from 10 different languages.
- A dynamic form to add multiple chapters with titles and content.
- Generates a .zip file containing the complete folder structure and Markdown files for the new course, based on the project's conventions.
- Creates placeholder files for selected languages, ready for translation.
- Includes a utility to update the `mkdocs.yml` file with configurations for newly added languages.

This tool streamlines the course creation process, reducing manual effort and potential errors.