### PR TITLE
fix: Use relative links for language switcher in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,37 +17,37 @@ theme:
 extra:
   alternate:
     - name: English
-      link: /
+      link: ./
       lang: en
     - name: Deutsch
-      link: /de/
+      link: ./de/
       lang: de
     - name: Français
-      link: /fr/
+      link: ./fr/
       lang: fr
     - name: हिन्दी
-      link: /hi/
+      link: ./hi/
       lang: hi
     - name: Italiano
-      link: /it/
+      link: ./it/
       lang: it
     - name: 日本語
-      link: /ja/
+      link: ./ja/
       lang: ja
     - name: Português
-      link: /pt/
+      link: ./pt/
       lang: pt
     - name: Română
-      link: /ro/
+      link: ./ro/
       lang: ro
     - name: Русский
-      link: /ru/
+      link: ./ru/
       lang: ru
     - name: Español
-      link: /es/
+      link: ./es/
       lang: es
     - name: 中文
-      link: /zh/
+      link: ./zh/
       lang: zh
 
 plugins:


### PR DESCRIPTION
This commit fixes a 404 error with the language switcher on the deployed GitHub Pages site.

The `extra.alternate` links in `mkdocs.yml` were configured with absolute paths (e.g., `/de/`), which do not work correctly when the site is hosted in a subdirectory.

This has been corrected by changing all language links to be relative (e.g., `./de/`). This ensures that the language switcher navigates correctly within the project's path on the server.