### PR TITLE
fix: Resolve race condition for editor initialization

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -95,7 +95,7 @@
 
     <!-- Main Application Logic -->
     <script>
-        document.addEventListener('DOMContentLoaded', () => {
+        window.onload = () => {
             const courseForm = document.getElementById('course-form');
             const chaptersContainer = document.getElementById('chapters-container');
             const addChapterBtn = document.getElementById('add-chapter');


### PR DESCRIPTION
This commit fixes a bug where the WYSIWYG editor would fail to load due to a race condition.

The application script was sometimes executing before the external Toast UI Editor library had fully downloaded and parsed. This was resolved by changing the script's event listener from `DOMContentLoaded` to `window.onload`, which ensures the script only runs after all page resources, including external libraries, are fully loaded.