### PR TITLE
fix(course-creator): Load webllm.js as a module

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Universal Course Creator</title>
-    <script src="libs/webllm.js" defer></script>
+    <script type="module" src="libs/webllm.js" defer></script>
     <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css" />
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 2rem auto; padding: 0 1rem; background-color: #f9f9f9; }


### PR DESCRIPTION
The `webllm.js` script uses ES module features (`export`). Without `type="module"`, browsers treat it as a classic script, causing a `SyntaxError` when `export` is encountered. This also leads to a `ReferenceError` because the `webllm` object is never defined on the global scope.

This commit adds `type="module"` to the script tag to ensure it's loaded correctly, resolving the console errors and allowing the AI features to initialize properly.