### PR TITLE
fix(course-creator): Fix module loading and editor text streaming

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -174,7 +174,7 @@
                             firstChunk = false;
                         } else {
                             if (target.exec) {
-                                target.exec('insertText', { text: delta });
+                                target.insertText(delta);
                             } else {
                                 target.value += delta;
                             }
@@ -183,7 +183,7 @@
                 } catch (err) {
                     const errorMessage = "\n\nError: " + err.message;
                     if (target.exec) {
-                        target.exec('insertText', { text: errorMessage });
+                        target.insertText(errorMessage);
                     } else {
                         target.value += errorMessage;
                     }


### PR DESCRIPTION
This commit resolves several issues in the course creator tool.

Module Loading:
- The `webllm.js` script is now correctly loaded as an ES module by adding `type="module"`.
- The main inline script is also converted to a module to allow for explicitly importing `webllm`, which resolves the `ReferenceError: webllm is not defined`.
- The redundant `DOMContentLoaded` listener is removed.

ToastUI Editor Streaming:
- Fixes a bug where only the first word of AI-generated content would appear in the editor.
- The code was incorrectly using `editor.exec('insertText', ...)` to stream text. This has been replaced with the correct API method, `editor.insertText()`, as per the official documentation. This resolves the `TypeError: this.wwCommands[e] is not a function`.