### PR TITLE
feat(course-creator): Update UI for course languages section

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -68,28 +68,28 @@
                 <button type="button" id="generate-desc-btn" class="btn btn-secondary btn-ai">AI</button>
             </div>
 
-            <fieldset>
-                <legend>Course Languages</legend>
-                <div class="lang-grid">
-                    <div class="lang-item"><input type="checkbox" id="lang-en" value="en" data-name="English" checked> <label for="lang-en">English</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-de" value="de" data-name="German"> <label for="lang-de">German</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-zh" value="zh" data-name="Mandarin Chinese"> <label for="lang-zh">Mandarin Chinese</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-es" value="es" data-name="Spanish"> <label for="lang-es">Spanish</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-hi" value="hi" data-name="Hindi"> <label for="lang-hi">Hindi</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-pt" value="pt" data-name="Portuguese"> <label for="lang-pt">Portuguese</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-ru" value="ru" data-name="Russian"> <label for="lang-ru">Russian</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-ja" value="ja" data-name="Japanese"> <label for="lang-ja">Japanese</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-fr" value="fr" data-name="French"> <label for="lang-fr">French</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-it" value="it" data-name="Italian"> <label for="lang-it">Italian</label></div>
-                    <div class="lang-item"><input type="checkbox" id="lang-ro" value="ro" data-name="Romanian"> <label for="lang-ro">Romanian</label></div>
-                </div>
-            </fieldset>
-
             <h2>Chapters</h2>
             <div id="chapters-container">
                 <!-- Chapters will be dynamically added here -->
             </div>
             <button type="button" id="add-chapter" class="btn btn-secondary">Add Chapter</button>
+
+            <fieldset>
+                <legend>Course Languages</legend>
+                <div class="lang-grid">
+                    <div class="lang-item">🇬🇧 <input type="checkbox" id="lang-en" value="en" data-name="English" checked> <label for="lang-en">English</label> <span style="font-weight: normal; font-style: italic; margin-left: 0.5rem;">(default)</span></div>
+                    <div class="lang-item">🇩🇪 <input type="checkbox" id="lang-de" value="de" data-name="German"> <label for="lang-de">German</label></div>
+                    <div class="lang-item">🇨🇳 <input type="checkbox" id="lang-zh" value="zh" data-name="Mandarin Chinese"> <label for="lang-zh">Mandarin Chinese</label></div>
+                    <div class="lang-item">🇪🇸 <input type="checkbox" id="lang-es" value="es" data-name="Spanish"> <label for="lang-es">Spanish</label></div>
+                    <div class="lang-item">🇮🇳 <input type="checkbox" id="lang-hi" value="hi" data-name="Hindi"> <label for="lang-hi">Hindi</label></div>
+                    <div class="lang-item">🇵🇹 <input type="checkbox" id="lang-pt" value="pt" data-name="Portuguese"> <label for="lang-pt">Portuguese</label></div>
+                    <div class="lang-item">🇷🇺 <input type="checkbox" id="lang-ru" value="ru" data-name="Russian"> <label for="lang-ru">Russian</label></div>
+                    <div class="lang-item">🇯🇵 <input type="checkbox" id="lang-ja" value="ja" data-name="Japanese"> <label for="lang-ja">Japanese</label></div>
+                    <div class="lang-item">🇫🇷 <input type="checkbox" id="lang-fr" value="fr" data-name="French"> <label for="lang-fr">French</label></div>
+                    <div class="lang-item">🇮🇹 <input type="checkbox" id="lang-it" value="it" data-name="Italian"> <label for="lang-it">Italian</label></div>
+                    <div class="lang-item">🇷🇴 <input type="checkbox" id="lang-ro" value="ro" data-name="Romanian"> <label for="lang-ro">Romanian</label></div>
+                </div>
+            </fieldset>
 
             <hr style="margin: 2rem 0;">
 


### PR DESCRIPTION
This commit implements several UI improvements to the course languages section based on user feedback.

- The entire "Course Languages" block has been moved to the end of the form, just before the final "Generate Course Files" button, to improve the form's logical flow.
- Flag emojis have been added next to each language to make them more easily identifiable.
- A "(default)" text indicator has been added next to the English language option to make the default choice explicit to the user.