### PR TITLE
feat(course-creator): Improve UX of course languages section

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -74,20 +74,20 @@
             </div>
             <button type="button" id="add-chapter" class="btn btn-secondary">Add Chapter</button>
 
-            <fieldset>
+            <fieldset style="margin-top: 2rem;">
                 <legend>Course Languages</legend>
                 <div class="lang-grid">
-                    <div class="lang-item">🇬🇧 <input type="checkbox" id="lang-en" value="en" data-name="English" checked> <label for="lang-en">English</label> <span style="font-weight: normal; font-style: italic; margin-left: 0.5rem;">(default)</span></div>
-                    <div class="lang-item">🇩🇪 <input type="checkbox" id="lang-de" value="de" data-name="German"> <label for="lang-de">German</label></div>
-                    <div class="lang-item">🇨🇳 <input type="checkbox" id="lang-zh" value="zh" data-name="Mandarin Chinese"> <label for="lang-zh">Mandarin Chinese</label></div>
-                    <div class="lang-item">🇪🇸 <input type="checkbox" id="lang-es" value="es" data-name="Spanish"> <label for="lang-es">Spanish</label></div>
-                    <div class="lang-item">🇮🇳 <input type="checkbox" id="lang-hi" value="hi" data-name="Hindi"> <label for="lang-hi">Hindi</label></div>
-                    <div class="lang-item">🇵🇹 <input type="checkbox" id="lang-pt" value="pt" data-name="Portuguese"> <label for="lang-pt">Portuguese</label></div>
-                    <div class="lang-item">🇷🇺 <input type="checkbox" id="lang-ru" value="ru" data-name="Russian"> <label for="lang-ru">Russian</label></div>
-                    <div class="lang-item">🇯🇵 <input type="checkbox" id="lang-ja" value="ja" data-name="Japanese"> <label for="lang-ja">Japanese</label></div>
-                    <div class="lang-item">🇫🇷 <input type="checkbox" id="lang-fr" value="fr" data-name="French"> <label for="lang-fr">French</label></div>
-                    <div class="lang-item">🇮🇹 <input type="checkbox" id="lang-it" value="it" data-name="Italian"> <label for="lang-it">Italian</label></div>
-                    <div class="lang-item">🇷🇴 <input type="checkbox" id="lang-ro" value="ro" data-name="Romanian"> <label for="lang-ro">Romanian</label></div>
+                    <div class="lang-item" title="English"><input type="checkbox" id="lang-en" value="en" data-name="English" checked> <label for="lang-en">🇬🇧</label> ⭐</div>
+                    <div class="lang-item" title="German"><input type="checkbox" id="lang-de" value="de" data-name="German"> <label for="lang-de">🇩🇪</label></div>
+                    <div class="lang-item" title="Mandarin Chinese"><input type="checkbox" id="lang-zh" value="zh" data-name="Mandarin Chinese"> <label for="lang-zh">🇨🇳</label></div>
+                    <div class="lang-item" title="Spanish"><input type="checkbox" id="lang-es" value="es" data-name="Spanish"> <label for="lang-es">🇪🇸</label></div>
+                    <div class="lang-item" title="Hindi"><input type="checkbox" id="lang-hi" value="hi" data-name="Hindi"> <label for="lang-hi">🇮🇳</label></div>
+                    <div class="lang-item" title="Portuguese"><input type="checkbox" id="lang-pt" value="pt" data-name="Portuguese"> <label for="lang-pt">🇵🇹</label></div>
+                    <div class="lang-item" title="Russian"><input type="checkbox" id="lang-ru" value="ru" data-name="Russian"> <label for="lang-ru">🇷🇺</label></div>
+                    <div class="lang-item" title="Japanese"><input type="checkbox" id="lang-ja" value="ja" data-name="Japanese"> <label for="lang-ja">🇯🇵</label></div>
+                    <div class="lang-item" title="French"><input type="checkbox" id="lang-fr" value="fr" data-name="French"> <label for="lang-fr">🇫🇷</label></div>
+                    <div class="lang-item" title="Italian"><input type="checkbox" id="lang-it" value="it" data-name="Italian"> <label for="lang-it">🇮🇹</label></div>
+                    <div class="lang-item" title="Romanian"><input type="checkbox" id="lang-ro" value="ro" data-name="Romanian"> <label for="lang-ro">🇷🇴</label></div>
                 </div>
             </fieldset>
 


### PR DESCRIPTION
This commit implements several UX improvements to the course languages section based on user feedback.

- The language text labels have been replaced with flag icons to provide a more visual and compact layout. The full language name is available via a tooltip on hover.
- The `(default)` text indicator for English has been replaced with a star (⭐) icon.
- A top margin has been added to the language block to increase its spacing from the elements above it.