### PR TITLE
feat(course-creator): Replace emoji flags with CDN images

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -77,17 +77,62 @@
             <fieldset style="margin-top: 2rem;">
                 <legend>Course Languages</legend>
                 <div class="lang-grid">
-                    <div class="lang-item" title="English"><input type="checkbox" id="lang-en" value="en" data-name="English" checked> <label for="lang-en">🇬🇧</label> ⭐</div>
-                    <div class="lang-item" title="German"><input type="checkbox" id="lang-de" value="de" data-name="German"> <label for="lang-de">🇩🇪</label></div>
-                    <div class="lang-item" title="Mandarin Chinese"><input type="checkbox" id="lang-zh" value="zh" data-name="Mandarin Chinese"> <label for="lang-zh">🇨🇳</label></div>
-                    <div class="lang-item" title="Spanish"><input type="checkbox" id="lang-es" value="es" data-name="Spanish"> <label for="lang-es">🇪🇸</label></div>
-                    <div class="lang-item" title="Hindi"><input type="checkbox" id="lang-hi" value="hi" data-name="Hindi"> <label for="lang-hi">🇮🇳</label></div>
-                    <div class="lang-item" title="Portuguese"><input type="checkbox" id="lang-pt" value="pt" data-name="Portuguese"> <label for="lang-pt">🇵🇹</label></div>
-                    <div class="lang-item" title="Russian"><input type="checkbox" id="lang-ru" value="ru" data-name="Russian"> <label for="lang-ru">🇷🇺</label></div>
-                    <div class="lang-item" title="Japanese"><input type="checkbox" id="lang-ja" value="ja" data-name="Japanese"> <label for="lang-ja">🇯🇵</label></div>
-                    <div class="lang-item" title="French"><input type="checkbox" id="lang-fr" value="fr" data-name="French"> <label for="lang-fr">🇫🇷</label></div>
-                    <div class="lang-item" title="Italian"><input type="checkbox" id="lang-it" value="it" data-name="Italian"> <label for="lang-it">🇮🇹</label></div>
-                    <div class="lang-item" title="Romanian"><input type="checkbox" id="lang-ro" value="ro" data-name="Romanian"> <label for="lang-ro">🇷🇴</label></div>
+                    <div class="lang-item" title="English">
+                        <img src="https://flagcdn.com/us.svg" alt="USA Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-en" style="flex-grow: 1;">English</label>
+                        <input type="checkbox" id="lang-en" value="en" data-name="English" checked>
+                        <span style="margin-left: 0.5rem;">⭐</span>
+                    </div>
+                    <div class="lang-item" title="German">
+                        <img src="https://flagcdn.com/de.svg" alt="German Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-de" style="flex-grow: 1;">German</label>
+                        <input type="checkbox" id="lang-de" value="de" data-name="German">
+                    </div>
+                    <div class="lang-item" title="Mandarin Chinese">
+                        <img src="https://flagcdn.com/cn.svg" alt="Chinese Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-zh" style="flex-grow: 1;">Mandarin Chinese</label>
+                        <input type="checkbox" id="lang-zh" value="zh" data-name="Mandarin Chinese">
+                    </div>
+                    <div class="lang-item" title="Spanish">
+                        <img src="https://flagcdn.com/es.svg" alt="Spanish Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-es" style="flex-grow: 1;">Spanish</label>
+                        <input type="checkbox" id="lang-es" value="es" data-name="Spanish">
+                    </div>
+                    <div class="lang-item" title="Hindi">
+                        <img src="https://flagcdn.com/in.svg" alt="Indian Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-hi" style="flex-grow: 1;">Hindi</label>
+                        <input type="checkbox" id="lang-hi" value="hi" data-name="Hindi">
+                    </div>
+                    <div class="lang-item" title="Portuguese">
+                        <img src="https://flagcdn.com/pt.svg" alt="Portuguese Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-pt" style="flex-grow: 1;">Portuguese</label>
+                        <input type="checkbox" id="lang-pt" value="pt" data-name="Portuguese">
+                    </div>
+                    <div class="lang-item" title="Russian">
+                        <img src="https://flagcdn.com/ru.svg" alt="Russian Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-ru" style="flex-grow: 1;">Russian</label>
+                        <input type="checkbox" id="lang-ru" value="ru" data-name="Russian">
+                    </div>
+                    <div class="lang-item" title="Japanese">
+                        <img src="https://flagcdn.com/jp.svg" alt="Japanese Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-ja" style="flex-grow: 1;">Japanese</label>
+                        <input type="checkbox" id="lang-ja" value="ja" data-name="Japanese">
+                    </div>
+                    <div class="lang-item" title="French">
+                        <img src="https://flagcdn.com/fr.svg" alt="French Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-fr" style="flex-grow: 1;">French</label>
+                        <input type="checkbox" id="lang-fr" value="fr" data-name="French">
+                    </div>
+                    <div class="lang-item" title="Italian">
+                        <img src="https://flagcdn.com/it.svg" alt="Italian Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-it" style="flex-grow: 1;">Italian</label>
+                        <input type="checkbox" id="lang-it" value="it" data-name="Italian">
+                    </div>
+                    <div class="lang-item" title="Romanian">
+                        <img src="https://flagcdn.com/ro.svg" alt="Romanian Flag" style="width: 24px; margin-right: 0.5rem;">
+                        <label for="lang-ro" style="flex-grow: 1;">Romanian</label>
+                        <input type="checkbox" id="lang-ro" value="ro" data-name="Romanian">
+                    </div>
                 </div>
             </fieldset>
 


### PR DESCRIPTION
This commit improves the language selector UI by replacing the unreliable Unicode flag emojis with robust SVG images served from a CDN (`flagcdn.com`).

This ensures that colored flags render correctly across all operating systems, resolving an issue where they appeared as two-letter country codes on some systems.

The language text labels (e.g., "English") have been restored next to the flags for clarity, as requested by the user. The US flag is now used for English.