### PR TITLE
Fix: Narrow language checkbox selector to prevent bug

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -356,7 +356,7 @@
 
                     const courseName = document.getElementById('course-name').value;
                 const courseDesc = document.getElementById('course-desc').value;
-                const selectedLangs = Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+                const selectedLangs = Array.from(document.querySelectorAll('.lang-grid input[type="checkbox"]:checked')).map(cb => cb.value);
 
                 if (selectedLangs.length === 0) {
                     alert('Please select at least one language.');


### PR DESCRIPTION
The previous selector `input[type="checkbox"]:checked` was too broad and would select any checked checkbox on the page. This caused a bug when the ToastUI editor was used to create a task list, as its checkboxes do not have a `value` attribute and would default to "on".

This commit narrows the selector to `.lang-grid input[type="checkbox"]:checked` to ensure that only checkboxes from the language selection grid are chosen. This prevents the "on" value from being processed as a language and fixes the bug.