### PR TITLE
Fix: Improve Ollama response handling and robustness

### DIFF
--- a/course-creator.html
+++ b/course-creator.html
@@ -293,6 +293,12 @@ Ensure the "chapters" array contains exactly ${numChapters} objects.`;
 
                 const data = await response.json();
                 const content = data.message.content;
+
+                if (!content || content.trim() === '') {
+                    aiStatus.textContent = `Error: The AI model returned an empty response. This can happen if the model is not suitable for generating structured JSON. Please try a different model (e.g., llama3) or a simpler prompt.`;
+                    return;
+                }
+
                 aiStatus.textContent = "AI generation complete. Parsing response and populating form...";
                 populateFormWithAIResponse(content);
             } catch (err) {
@@ -303,7 +309,12 @@ Ensure the "chapters" array contains exactly ${numChapters} objects.`;
 
         function populateFormWithAIResponse(jsonString) {
             try {
-                const courseData = JSON.parse(jsonString);
+                let cleanJsonString = jsonString.trim();
+                if (cleanJsonString.startsWith("```json")) {
+                    cleanJsonString = cleanJsonString.substring(7, cleanJsonString.lastIndexOf("```")).trim();
+                }
+
+                const courseData = JSON.parse(cleanJsonString);
 
                 if (!courseData.course_title || !courseData.course_description || !courseData.chapters) {
                     throw new Error("The AI response is missing required fields (course_title, course_description, chapters).");


### PR DESCRIPTION
This commit adds two layers of protection to make the application more robust when handling responses from the Ollama API, preventing crashes from unexpected or malformed model outputs.

1.  **Empty Response Check:** The code now explicitly checks if the AI model returns an empty or whitespace-only response. If so, it halts execution and displays a user-friendly error message with suggestions on how to proceed.

2.  **JSON Cleaning:** The JSON parsing logic now automatically strips common markdown code fences (e.g., \`\`\`json ... \`\`\`) from the AI's response before attempting to parse it. This makes the application more resilient to models that wrap their JSON output in markdown.

These changes directly address the `Unexpected end of JSON input` error and improve the overall stability of the AI generation feature.