### PR TITLE
Feat: Add startup scripts for easy launching

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,14 @@
+@echo off
+echo Starting a local web server...
+
+:: Start the python server in a new window
+start "Python HTTP Server" cmd /c "python -m http.server"
+
+:: Give the server a moment to start
+timeout /t 1 > nul
+
+echo Opening http://localhost:8000/course-creator.html in your default browser...
+start http://localhost:8000/course-creator.html
+
+echo.
+echo The server is running in a separate window. Close that window to stop the server.

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+echo "Starting a local web server..."
+
+# Start the python server in the background
+python3 -m http.server &
+SERVER_PID=$!
+
+# Give the server a moment to start
+sleep 1
+
+URL="http://localhost:8000/course-creator.html"
+echo "Opening $URL in your default browser..."
+
+# Open the URL in the default browser based on OS
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    xdg-open "$URL"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    open "$URL"
+else
+    echo "Could not detect OS to open browser automatically. Please open the URL manually."
+fi
+
+echo "Server is running in the background (PID: $SERVER_PID)."
+echo "To stop the server, run: kill $SERVER_PID"


### PR DESCRIPTION
This commit adds two convenience scripts, `start.sh` and `start.bat`, to make it easier for users to run the application.

- `start.sh`: For macOS and Linux users. It starts a `python3 -m http.server`, opens the application in the default browser, and runs the server in the background.
- `start.bat`: For Windows users. It starts the python server in a new window and opens the application in the default browser.

These scripts simplify the process of running the course creator locally.