### PR TITLE
fix(i18n): Correct language switcher behavior

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,37 +21,37 @@ extra_css:
 extra:
   alternate:
   - name: English
-    link: /emotions-for-engineers/
+    link: /
     lang: en
   - name: Deutsch
-    link: /emotions-for-engineers/de/
+    link: /de/
     lang: de
   - name: Français
-    link: /emotions-for-engineers/fr/
+    link: /fr/
     lang: fr
   - name: हिन्दी
-    link: /emotions-for-engineers/hi/
+    link: /hi/
     lang: hi
   - name: Italiano
-    link: /emotions-for-engineers/it/
+    link: /it/
     lang: it
   - name: 日本語
-    link: /emotions-for-engineers/ja/
+    link: /ja/
     lang: ja
   - name: Português
-    link: /emotions-for-engineers/pt/
+    link: /pt/
     lang: pt
   - name: Română
-    link: /emotions-for-engineers/ro/
+    link: /ro/
     lang: ro
   - name: Русский
-    link: /emotions-for-engineers/ru/
+    link: /ru/
     lang: ru
   - name: Español
-    link: /emotions-for-engineers/es/
+    link: /es/
     lang: es
   - name: 中文
-    link: /emotions-for-engineers/zh/
+    link: /zh/
     lang: zh
 
 plugins:


### PR DESCRIPTION
This commit fixes the contextual language switcher. Previously, when changing languages on a page like "About", the user was incorrectly redirected to the main page of the new language.

The issue was resolved by updating the `extra.alternate` links in the base `mkdocs.yml` file. The links are now relative to the `site_url` (e.g., `/` for English, `/de/` for German), which allows the `mkdocs-static-i18n` plugin to correctly build the contextual page-to-page links.

This change ensures a seamless user experience when navigating between language versions of the site.