### PR TITLE
fix: Resolve language switcher bugs and warnings

### DIFF
--- a/build_site.py
+++ b/build_site.py
@@ -89,7 +89,8 @@ def main():
     print("Building navigation structure for mkdocs.yml...")
     course_dirs = get_course_dirs()
     new_nav = [
-        {'Available Courses': 'index.md'},
+        {'Home': 'index.md'},
+        {'Available Courses': 'courses.md'},
         {'About': 'about.md'}
     ]
 
@@ -169,9 +170,9 @@ def main():
         index_content += "\n</div>\n"
 
         if cards_content:
-            index_file_path = DOCS_DIR / f"index.{lang}.md"
-            index_file_path.write_text(index_content, encoding="utf-8")
-            print(f"✅ Successfully generated index.{lang}.md")
+            courses_file_path = DOCS_DIR / f"courses.{lang}.md"
+            courses_file_path.write_text(index_content, encoding="utf-8")
+            print(f"✅ Successfully generated courses.{lang}.md")
 
 if __name__ == "__main__":
     main()

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -3,8 +3,10 @@
  */
 
 /* Hide the course-specific tabs from the main header navigation. */
-/* We only want to show "Available Courses" and "About". */
-.md-tabs__item:nth-child(n+3) {
+/* We want to show "Available Courses" (2nd) and "About" (3rd). */
+/* So, we hide the "Home" tab (1st) and all course tabs (from 4th onwards). */
+.md-tabs__item:first-child,
+.md-tabs__item:nth-child(n+4) {
     display: none;
 }
 

--- a/docs/courses.de.md
+++ b/docs/courses.de.md
@@ -1,0 +1,23 @@
+# Verfügbare Kurse
+
+Willkommen! Dies ist Ihr zentraler Hub für Lernen und Wachstum. Unten finden Sie eine kuratierte Liste von Kursen, die darauf ausgelegt sind, Ihre emotionale Intelligenz und beruflichen Fähigkeiten zu verbessern. Durchsuchen Sie die verfügbaren Optionen und klicken Sie auf "Lernen starten", um Ihre Reise zu beginnen.
+
+<div class="grid cards" markdown>
+
+-   __Emotionale Meisterheit: Die Befreiung Ihres inneren Gleichgewichts__
+
+    ---
+
+    Lerne, deine täglichen Emotionen zu meistern und einen ausgeglicheneren, erfüllenderen Lebensstil zu erlangen.
+
+    [:octicons-arrow-right-24: Start Learning](emotional-mastery-unleashing-your-inner-balance/index.md)
+
+-   __Tuning der Maschinen: Meisterung der emotionalen Intelligenz für Maschineningenieure__
+
+    ---
+
+    Erwärmen Sie Ihre Ingenieurkenntnisse auf die nächste Ebene, indem Sie lernen, komplexe Emotionen zu navigieren, stärkere Teams zu bauen und Projekte pünktlich abzuschließen. Diese umfassende Kursequips Maschinenbauingenieure mit Strategien zur emotionalen Intelligenz, um in hohen Druckumgebungen zu glänzen, Konflikte effektiv zu managen und Innovation durch Zusammenarbeit anztreiben.
+
+    [:octicons-arrow-right-24: Start Learning](tuning-the-machines-mastering-emotional-intelligence-for-machinery-construction-engineers/index.md)
+
+</div>

--- a/docs/courses.en.md
+++ b/docs/courses.en.md
@@ -1,0 +1,47 @@
+# Available Courses
+
+Welcome! This is your central hub for learning and growth. Below you'll find a curated list of courses designed to enhance your emotional intelligence and professional skills. Browse the available options and click "Start Learning" to begin your journey.
+
+<div class="grid cards" markdown>
+
+-   __Collect Emotions__
+
+    ---
+
+    asadasaf
+
+    [:octicons-arrow-right-24: Start Learning](collect-emotions/index.md)
+
+-   __Welcome to Emotions for Engineers__
+
+    ---
+
+    An example course to demonstrate the structure of this repository and the features of the generated website.
+
+    [:octicons-arrow-right-24: Start Learning](course-example/index.md)
+
+-   __Emotional Mastery: Unleashing Your Inner Balance__
+
+    ---
+
+    Learn to master your daily emotions and unlock a more balanced, fulfilling life.
+
+    [:octicons-arrow-right-24: Start Learning](emotional-mastery-unleashing-your-inner-balance/index.md)
+
+-   __Tuning the Machines: Mastering Emotional Intelligence for Machinery Construction Engineers__
+
+    ---
+
+    Take your engineering skills to the next level by learning how to navigate complex emotions, build stronger teams, and deliver projects on time. This comprehensive course equips machinery construction engineers with emotional intelligence strategies to excel in high-pressure environments, manage conflicts effectively, and drive innovation through collaboration.
+
+    [:octicons-arrow-right-24: Start Learning](tuning-the-machines-mastering-emotional-intelligence-for-machinery-construction-engineers/index.md)
+
+-   __Unlock the Power of Emotional Awareness: Collecting Your Daily Emotions__
+
+    ---
+
+    Are you tired of feeling like you're living on autopilot, unaware of the emotions that drive your thoughts and behaviors? Do you struggle to identify and manage your emotions, leading to feelings of overwhelm and stress?
+
+    [:octicons-arrow-right-24: Start Learning](unlock-the-power-of-emotional-awareness-collecting-your-daily-emotions/index.md)
+
+</div>

--- a/docs/courses.pt.md
+++ b/docs/courses.pt.md
@@ -1,0 +1,15 @@
+# Available Courses
+
+Welcome! This is your central hub for learning and growth. Below you'll find a curated list of courses designed to enhance your emotional intelligence and professional skills. Browse the available options and click "Start Learning" to begin your journey.
+
+<div class="grid cards" markdown>
+
+-   __Domínio Emocional: Desencadeando o Equilíbrio Interno__
+
+    ---
+
+    Aprenda a dominar suas emoções diárias e desbloqueie uma vida mais equilibrada e gratificante.
+
+    [:octicons-arrow-right-24: Start Learning](emotional-mastery-unleashing-your-inner-balance/index.md)
+
+</div>

--- a/docs/courses.ro.md
+++ b/docs/courses.ro.md
@@ -1,0 +1,31 @@
+# Available Courses
+
+Welcome! This is your central hub for learning and growth. Below you'll find a curated list of courses designed to enhance your emotional intelligence and professional skills. Browse the available options and click "Start Learning" to begin your journey.
+
+<div class="grid cards" markdown>
+
+-   __Collect Emotions__
+
+    ---
+
+    asadasaf
+
+    [:octicons-arrow-right-24: Start Learning](collect-emotions/index.md)
+
+-   __Măiestria Emoțională: Eliberarea echilibrului interior tău__
+
+    ---
+
+    Învățați să dominați emoțiile tale zilnice și descoperiți o viață mai echilibrată și mai plină de satisfacție.
+
+    [:octicons-arrow-right-24: Start Learning](emotional-mastery-unleashing-your-inner-balance/index.md)
+
+-   __Pregătirea Mașinilor: Îmbunătățirea Inteligenței Emoționale pentru Inginerii de Construcție a Mașinilor__
+
+    ---
+
+    Pune abilitățile de inginer la un nivel superior învățând cum să navighezi emoțiile complexe, construiești echipe mai puternice și livrezi proiectele la timp. Acest curs complet echipa inginerii constructiei mașinilor cu strategii de inteligență emoțională pentru a excela în medii cu presiune ridicată, gestionarea conflictelor în mod efectiv și împingeți inovația prin colaborare.
+
+    [:octicons-arrow-right-24: Start Learning](tuning-the-machines-mastering-emotional-intelligence-for-machinery-construction-engineers/index.md)
+
+</div>

--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -1,23 +1,6 @@
-# Verfügbare Kurse
-
-Willkommen! Dies ist Ihr zentraler Hub für Lernen und Wachstum. Unten finden Sie eine kuratierte Liste von Kursen, die darauf ausgelegt sind, Ihre emotionale Intelligenz und beruflichen Fähigkeiten zu verbessern. Durchsuchen Sie die verfügbaren Optionen und klicken Sie auf "Lernen starten", um Ihre Reise zu beginnen.
-
-<div class="grid cards" markdown>
-
--   __Emotionale Meisterheit: Die Befreiung Ihres inneren Gleichgewichts__
-
-    ---
-
-    Lerne, deine täglichen Emotionen zu meistern und einen ausgeglicheneren, erfüllenderen Lebensstil zu erlangen.
-
-    [:octicons-arrow-right-24: Start Learning](emotional-mastery-unleashing-your-inner-balance/index.md)
-
--   __Tuning der Maschinen: Meisterung der emotionalen Intelligenz für Maschineningenieure__
-
-    ---
-
-    Erwärmen Sie Ihre Ingenieurkenntnisse auf die nächste Ebene, indem Sie lernen, komplexe Emotionen zu navigieren, stärkere Teams zu bauen und Projekte pünktlich abzuschließen. Diese umfassende Kursequips Maschinenbauingenieure mit Strategien zur emotionalen Intelligenz, um in hohen Druckumgebungen zu glänzen, Konflikte effektiv zu managen und Innovation durch Zusammenarbeit anztreiben.
-
-    [:octicons-arrow-right-24: Start Learning](tuning-the-machines-mastering-emotional-intelligence-for-machinery-construction-engineers/index.md)
-
-</div>
+---
+hide:
+  - navigation
+  - toc
+redirect: courses/
+---

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,47 +1,6 @@
-# Available Courses
-
-Welcome! This is your central hub for learning and growth. Below you'll find a curated list of courses designed to enhance your emotional intelligence and professional skills. Browse the available options and click "Start Learning" to begin your journey.
-
-<div class="grid cards" markdown>
-
--   __Collect Emotions__
-
-    ---
-
-    asadasaf
-
-    [:octicons-arrow-right-24: Start Learning](collect-emotions/index.md)
-
--   __Welcome to Emotions for Engineers__
-
-    ---
-
-    An example course to demonstrate the structure of this repository and the features of the generated website.
-
-    [:octicons-arrow-right-24: Start Learning](course-example/index.md)
-
--   __Emotional Mastery: Unleashing Your Inner Balance__
-
-    ---
-
-    Learn to master your daily emotions and unlock a more balanced, fulfilling life.
-
-    [:octicons-arrow-right-24: Start Learning](emotional-mastery-unleashing-your-inner-balance/index.md)
-
--   __Tuning the Machines: Mastering Emotional Intelligence for Machinery Construction Engineers__
-
-    ---
-
-    Take your engineering skills to the next level by learning how to navigate complex emotions, build stronger teams, and deliver projects on time. This comprehensive course equips machinery construction engineers with emotional intelligence strategies to excel in high-pressure environments, manage conflicts effectively, and drive innovation through collaboration.
-
-    [:octicons-arrow-right-24: Start Learning](tuning-the-machines-mastering-emotional-intelligence-for-machinery-construction-engineers/index.md)
-
--   __Unlock the Power of Emotional Awareness: Collecting Your Daily Emotions__
-
-    ---
-
-    Are you tired of feeling like you're living on autopilot, unaware of the emotions that drive your thoughts and behaviors? Do you struggle to identify and manage your emotions, leading to feelings of overwhelm and stress?
-
-    [:octicons-arrow-right-24: Start Learning](unlock-the-power-of-emotional-awareness-collecting-your-daily-emotions/index.md)
-
-</div>
+---
+hide:
+  - navigation
+  - toc
+redirect: courses/
+---

--- a/docs/index.pt.md
+++ b/docs/index.pt.md
@@ -1,15 +1,6 @@
-# Available Courses
-
-Welcome! This is your central hub for learning and growth. Below you'll find a curated list of courses designed to enhance your emotional intelligence and professional skills. Browse the available options and click "Start Learning" to begin your journey.
-
-<div class="grid cards" markdown>
-
--   __Domínio Emocional: Desencadeando o Equilíbrio Interno__
-
-    ---
-
-    Aprenda a dominar suas emoções diárias e desbloqueie uma vida mais equilibrada e gratificante.
-
-    [:octicons-arrow-right-24: Start Learning](emotional-mastery-unleashing-your-inner-balance/index.md)
-
-</div>
+---
+hide:
+  - navigation
+  - toc
+redirect: courses/
+---

--- a/docs/index.ro.md
+++ b/docs/index.ro.md
@@ -1,31 +1,6 @@
-# Available Courses
-
-Welcome! This is your central hub for learning and growth. Below you'll find a curated list of courses designed to enhance your emotional intelligence and professional skills. Browse the available options and click "Start Learning" to begin your journey.
-
-<div class="grid cards" markdown>
-
--   __Collect Emotions__
-
-    ---
-
-    asadasaf
-
-    [:octicons-arrow-right-24: Start Learning](collect-emotions/index.md)
-
--   __Măiestria Emoțională: Eliberarea echilibrului interior tău__
-
-    ---
-
-    Învățați să dominați emoțiile tale zilnice și descoperiți o viață mai echilibrată și mai plină de satisfacție.
-
-    [:octicons-arrow-right-24: Start Learning](emotional-mastery-unleashing-your-inner-balance/index.md)
-
--   __Pregătirea Mașinilor: Îmbunătățirea Inteligenței Emoționale pentru Inginerii de Construcție a Mașinilor__
-
-    ---
-
-    Pune abilitățile de inginer la un nivel superior învățând cum să navighezi emoțiile complexe, construiești echipe mai puternice și livrezi proiectele la timp. Acest curs complet echipa inginerii constructiei mașinilor cu strategii de inteligență emoțională pentru a excela în medii cu presiune ridicată, gestionarea conflictelor în mod efectiv și împingeți inovația prin colaborare.
-
-    [:octicons-arrow-right-24: Start Learning](tuning-the-machines-mastering-emotional-intelligence-for-machinery-construction-engineers/index.md)
-
-</div>
+---
+hide:
+  - navigation
+  - toc
+redirect: courses/
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,39 +20,39 @@ extra_css:
 
 extra:
   alternate:
-  - name: English
-    link: /
+  - name: EN
     lang: en
-  - name: Deutsch
-    link: /de/
+    link: /
+  - name: DE
     lang: de
-  - name: Français
-    link: /fr/
+    link: /de/
+  - name: FR
     lang: fr
-  - name: हिन्दी
-    link: /hi/
+    link: /fr/
+  - name: HI
     lang: hi
-  - name: Italiano
-    link: /it/
+    link: /hi/
+  - name: IT
     lang: it
-  - name: 日本語
-    link: /ja/
+    link: /it/
+  - name: JA
     lang: ja
-  - name: Português
-    link: /pt/
+    link: /ja/
+  - name: PT
     lang: pt
-  - name: Română
-    link: /ro/
+    link: /pt/
+  - name: RO
     lang: ro
-  - name: Русский
-    link: /ru/
+    link: /ro/
+  - name: RU
     lang: ru
-  - name: Español
-    link: /es/
+    link: /ru/
+  - name: ES
     lang: es
-  - name: 中文
-    link: /zh/
+    link: /es/
+  - name: ZH
     lang: zh
+    link: /zh/
 
 plugins:
 - search
@@ -89,7 +89,8 @@ markdown_extensions:
     emoji_index: !!python/name:material.extensions.emoji.twemoji
     emoji_generator: !!python/name:material.extensions.emoji.to_svg
 nav:
-- Available Courses: index.md
+- Home: index.md
+- Available Courses: courses.md
 - About: about.md
 - Collect Emotions:
   - Overview: collect-emotions/index.md


### PR DESCRIPTION
This commit resolves two outstanding issues with the language switcher and cleans up all build warnings.

1.  **Fix 404s on Language Switch from Homepage:**
    - The main course listing has been moved from `index.md` to a dedicated `courses.md` page.
    - The root `index.md` is now a simple redirect to the `courses` page.
    - This provides a stable, non-root URL for the language switcher to work with, resolving the 404 errors.

2.  **Display Current Language Name:**
    - The `name` field in the `extra.alternate` section of `mkdocs.yml` has been updated to use short codes (e.g., "EN", "DE"). This allows the Material theme to correctly display the current language next to the switcher icon.

3.  **Resolve Build Warnings:**
    - The `build_site.py` script has been updated to include the new `index.md` redirect page in the `nav` structure, which resolves the "Could not find a homepage" warning from the `i18n` plugin.
    - The CSS has been updated to hide this new "Home" tab, preserving the desired UI.

The build process is now clean, and the language switching functionality is robust and user-friendly.