### PR TITLE
feat: Add homepage content and JS-based language switcher fix

### DIFF
--- a/docs/assets/js/language_display.js
+++ b/docs/assets/js/language_display.js
@@ -1,0 +1,42 @@
+// docs/assets/js/language_display.js
+
+// This script adds the name of the current language next to the language switcher icon.
+// It's a workaround for a conflict between the i18n plugin and the Material theme.
+
+document.addEventListener("DOMContentLoaded", function() {
+  // Mapping of language codes to their full names.
+  // This needs to be kept in sync with the `plugins.i18n.languages` section of mkdocs.yml.
+  const languageNames = {
+    "en": "English",
+    "de": "Deutsch",
+    "fr": "Français",
+    "hi": "हिन्दी",
+    "it": "Italiano",
+    "ja": "日本語",
+    "pt": "Português",
+    "ro": "Română",
+    "ru": "Русский",
+    "es": "Español",
+    "zh": "中文"
+  };
+
+  // Find the language switcher button
+  const langSwitcher = document.querySelector(".md-header__option .md-select");
+
+  if (langSwitcher) {
+    // Get the current language from the <html> tag
+    const currentLang = document.documentElement.lang;
+
+    // Get the full name, default to the code if not found
+    const currentLangName = languageNames[currentLang] || currentLang;
+
+    // Create a new span element to hold the language name
+    const langNameSpan = document.createElement("span");
+    langNameSpan.className = "md-header__button md-header__button--active";
+    langNameSpan.textContent = currentLangName;
+    langNameSpan.style.marginLeft = "0.2rem"; // Add a little space
+
+    // Insert the new span right before the language switcher's globe icon
+    langSwitcher.insertBefore(langNameSpan, langSwitcher.querySelector(".md-icon"));
+  }
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,9 @@ theme:
 extra_css:
 - assets/css/custom.css
 
+extra_javascript:
+- assets/js/language_display.js
+
 extra:
   alternate:
   - name: English
@@ -81,7 +84,6 @@ plugins:
       name: Español
     - locale: zh
       name: 中文
-    reconfigure_material: false
 
 markdown_extensions:
 - attr_list


### PR DESCRIPTION
This commit implements the final set of user-requested enhancements and bug fixes.

1.  **Homepage Content:**
    - The root `index.md` page for each language is now populated with welcoming content and a call-to-action button, replacing the previous redirect.

2.  **Language Switcher Display Fix:**
    - A custom Javascript file (`docs/assets/js/language_display.js`) has been added to dynamically insert the current language's name next to the switcher icon. This provides a robust, client-side solution to the display issue without compromising the i18n plugin's critical link-generation functionality.
    - The `mkdocs.yml` configuration has been updated to include this new script and to restore the correct i18n plugin settings.

3.  **URL Path Bug Fix:**
    - The main course listing page was moved from `index.md` to `courses.md` to resolve a bug where the language switcher would generate incorrect URLs on the site's root page.
    - The `build_site.py` script has been updated to accommodate this new page structure.

This completes the feature development, resulting in a fully automated, user-friendly, and bug-free site structure.