### PR TITLE
fix: Correct path to webllm.js

### DIFF
--- a/docs/course-creator.html
+++ b/docs/course-creator.html
@@ -225,7 +225,7 @@
 
     <!-- Main Application Logic -->
     <script type="module">
-        import { CreateWebWorkerEngine } from '../libs/webllm.js';
+        import { CreateWebWorkerEngine } from './libs/webllm.js';
 
         const WEBLLM_MODEL_ID = "Phi-3-mini-4k-instruct";
 


### PR DESCRIPTION
This commit corrects the path to the `webllm.js` library in `docs/course-creator.html`. This resolves a 404 error that was preventing the in-browser WebLLM from loading.