### PR TITLE
This commit fixes a runtime error that occurred when using the WebLLM…

### DIFF
--- a/docs/course-creator.html
+++ b/docs/course-creator.html
@@ -302,9 +302,12 @@
                 if (!webllmEngine) {
                     throw new Error("WebLLM engine is not initialized.");
                 }
-                // The WebLLM API is slightly different, we can use the simple `generate` method
-                const reply = await webllmEngine.generate(systemPrompt);
-                return reply;
+                // Use the OpenAI-compatible chat completions API
+                const reply = await webllmEngine.chat.completions.create({
+                    messages: [{ role: 'user', content: systemPrompt }],
+                    stream: false
+                });
+                return reply.choices[0].message.content;
 
             } else {
                 throw new Error("No valid AI provider is configured.");


### PR DESCRIPTION
… fallback.

The previous implementation incorrectly used `engine.generate()`, which is not a function on the WebLLM engine object.

This has been corrected to use the proper OpenAI-compatible API: `engine.chat.completions.create()`. The code now also correctly parses the response from the `reply.choices[0].message.content` field.