### PR TITLE
docs: Update dependency info and add security note

### DIFF
--- a/docs/course-creator.html
+++ b/docs/course-creator.html
@@ -82,6 +82,7 @@
                 <li>Review and edit the generated content as needed.</li>
                 <li>Select the languages you want to translate the course into.</li>
                 <li>Click "Generate Course Files". This will create a .zip file with all the markdown files.</li>
+                <li><strong>Security Note:</strong> When downloading new versions of this tool from the releases page, always verify the checksums of the downloaded assets to ensure they have not been tampered with.</li>
             </ol>
         </div>
 
@@ -237,8 +238,8 @@
        - Website: https://ui.toast.com/tui-editor
 
     4. WebLLM
-       - Version: Dynamically loaded from CDN.
-       - Path: https://esm.run/@mlc-ai/web-llm
+       - Version: 0.2.27
+       - Path: ./assets/vendor/webllm/webllm.js
        - License: Apache 2.0
        - Website: https://webllm.mlc.ai/
     -->


### PR DESCRIPTION
Corrected the comment for the `webllm` library in `docs/course-creator.html` to indicate that it is a local file, not loaded from a CDN.

Added a security note to the "How to Use" section in `docs/course-creator.html` advising users to verify release checksums.