### PR TITLE
Fix CSP errors by isolating components in iframes

### DIFF
--- a/docs/editor_iframe.html
+++ b/docs/editor_iframe.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="style-src 'self' 'unsafe-inline';">
+    <title>Editor</title>
+    <link rel="stylesheet" href="./assets/css/toastui-editor.min.css" />
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+        }
+    </style>
+</head>
+<body>
+    <div id="editor"></div>
+
+    <script src="./assets/js/toastui-editor-all.min.js"></script>
+    <script>
+        const urlParams = new URLSearchParams(window.location.search);
+        const chapterId = urlParams.get('id');
+
+        const editor = new toastui.Editor({
+            el: document.querySelector('#editor'),
+            height: '100%',
+            initialEditType: 'wysiwyg',
+            previewStyle: 'vertical',
+            events: {
+                change: () => {
+                    parent.postMessage({
+                        type: 'content-changed',
+                        content: editor.getMarkdown(),
+                        id: chapterId
+                    }, '*');
+                }
+            }
+        });
+
+        window.addEventListener('message', (event) => {
+            if (event.data.type === 'set-content') {
+                editor.setMarkdown(event.data.content || '');
+            }
+        });
+
+        parent.postMessage({ type: 'editor-ready', id: chapterId }, '*');
+    </script>
+</body>
+</html>

--- a/docs/webllm_iframe.html
+++ b/docs/webllm_iframe.html
@@ -6,47 +6,6 @@
     <title>WebLLM Worker</title>
 </head>
 <body>
-    <script type="module">
-        import * as webllm from "./assets/vendor/webllm/webllm.js";
-
-        let webllmEngine;
-        const WEBLLM_MODEL_ID = "Phi-3-mini-4k-instruct-q4f16_1-MLC";
-
-        async function initializeWebLLM() {
-            try {
-                const engine = await webllm.CreateMLCEngine(WEBLLM_MODEL_ID, {});
-                webllmEngine = engine;
-                parent.postMessage({ type: 'webllm-ready' }, '*');
-            } catch (err) {
-                console.error("WebLLM Initialization Error in iframe:", err);
-                parent.postMessage({ type: 'webllm-error', error: err.message }, '*');
-            }
-        }
-
-        async function generateText(prompt) {
-            if (!webllmEngine) {
-                throw new Error("WebLLM engine is not initialized.");
-            }
-            const reply = await webllmEngine.chat.completions.create({
-                messages: [{ role: 'user', content: prompt }],
-                stream: false
-            });
-            return reply.choices[0].message.content;
-        }
-
-        window.addEventListener('message', async (event) => {
-            if (event.data && event.data.type === 'generate-text') {
-                try {
-                    const prompt = event.data.prompt;
-                    const result = await generateText(prompt);
-                    parent.postMessage({ type: 'generation-result', result: result, id: event.data.id }, '*');
-                } catch (err) {
-                    parent.postMessage({ type: 'generation-error', error: err.message, id: event.data.id }, '*');
-                }
-            }
-        });
-
-        initializeWebLLM();
-    </script>
+    <script type="module" src="./webllm_iframe.js"></script>
 </body>
 </html>

--- a/docs/webllm_iframe.js
+++ b/docs/webllm_iframe.js
@@ -1,0 +1,40 @@
+import * as webllm from "./assets/vendor/webllm/webllm.js";
+
+let webllmEngine;
+const WEBLLM_MODEL_ID = "Phi-3-mini-4k-instruct-q4f16_1-MLC";
+
+async function initializeWebLLM() {
+    try {
+        const engine = await webllm.CreateMLCEngine(WEBLLM_MODEL_ID, {});
+        webllmEngine = engine;
+        parent.postMessage({ type: 'webllm-ready' }, '*');
+    } catch (err) {
+        console.error("WebLLM Initialization Error in iframe:", err);
+        parent.postMessage({ type: 'webllm-error', error: err.message }, '*');
+    }
+}
+
+async function generateText(prompt) {
+    if (!webllmEngine) {
+        throw new Error("WebLLM engine is not initialized.");
+    }
+    const reply = await webllmEngine.chat.completions.create({
+        messages: [{ role: 'user', content: prompt }],
+        stream: false
+    });
+    return reply.choices[0].message.content;
+}
+
+window.addEventListener('message', async (event) => {
+    if (event.data && event.data.type === 'generate-text') {
+        try {
+            const prompt = event.data.prompt;
+            const result = await generateText(prompt);
+            parent.postMessage({ type: 'generation-result', result: result, id: event.data.id }, '*');
+        } catch (err) {
+            parent.postMessage({ type: 'generation-error', error: err.message, id: event.data.id }, '*');
+        }
+    }
+});
+
+initializeWebLLM();


### PR DESCRIPTION
This commit resolves all remaining Content Security Policy (CSP) violations by isolating components with less strict security requirements into iframes.

The changes include:
- Isolating the ToastUI editor, which requires `'unsafe-inline'` styles, into its own `editor_iframe.html`.
- Refactoring `course-creator.js` to manage and communicate with the editor iframes via `postMessage`.
- Fixing the WebLLM iframe by moving its inline script to an external file (`webllm_iframe.js`), resolving the final script-related CSP issue.
- Updating the main page's CSP to be more secure, without requiring `'unsafe-inline'` or `'unsafe-eval'`.