### PR TITLE
fix: Correct the import path for webllm.js

### DIFF
--- a/docs/assets/js/webllm_iframe.js
+++ b/docs/assets/js/webllm_iframe.js
@@ -1,4 +1,4 @@
-import * as webllm from "./assets/vendor/webllm/webllm.js";
+import * as webllm from "../vendor/webllm/webllm.js";
 
 let webllmEngine;
 const WEBLLM_MODEL_ID = "Phi-3-mini-4k-instruct-q4f16_1-MLC";


### PR DESCRIPTION
This commit fixes a 404 "Not Found" error for `webllm.js`. The error was caused by an incorrect relative path in `webllm_iframe.js` after the file was moved to the `docs/assets/js` directory.

The import path has been updated to correctly resolve to the `webllm.js` library in the `docs/assets/vendor` directory.