### PR TITLE
docs: Revise README and add Help modal to UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,81 @@
-# Universal Course Content Repository
+# Universal Course Platform
 
-This repository is designed to be the "absolute source" for your course content. It uses Markdown for content and MkDocs for generating a beautiful, searchable, and multi-language website that is automatically deployed to GitHub Pages.
+This repository serves a dual purpose:
+
+1.  **A Content Publishing Platform:** It uses MkDocs to build and deploy beautiful, searchable, multi-language course websites from Markdown files.
+2.  **An AI-Powered Creation Tool:** It includes the "Universal Course Creator," a powerful, browser-based tool that uses AI to help you generate entire courses from a single prompt.
+
+This allows you to manage the entire lifecycle of your course content—from creation to publication—in one place.
 
 [![License: CC BY-SA 4.0](https://licensebuttons.net/l/by-sa/4.0/88x31.png)](https://creativecommons.org/licenses/by-sa/4.0/)
 
 This project is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](./LICENSE).
 
-## Features
-- **Multi-Language Support:** Fully configured for English and German, with a language switcher. Easily extensible to other languages.
-- **Automated Deployment:** Every push to the `main` branch automatically builds and deploys the latest version of the site to GitHub Pages.
-- **Clean Navigation:** A contextual sidebar shows only the chapters for the course you are currently viewing.
-- **Markdown-Based:** All content is written in simple Markdown files.
+---
 
-## Folder Structure
+## Part 1: The Universal Course Creator Tool
 
-The repository is organized to support multiple courses and multiple languages using a file-suffix convention.
+The Universal Course Creator is a standalone HTML file (`docs/course-creator.html`) that allows you to generate complete, multi-chapter courses using a variety of AI providers.
 
-```
-.
-├── docs/
-│   ├── index.en.md          # Homepage for English
-│   ├── index.de.md          # Homepage for German
-│   └── course-example/
-│       ├── 01-introduction.en.md
-│       ├── 01-introduction.de.md
-│       └── ...
-├── .gitignore
-├── mkdocs.yml
-└── requirements.txt
-```
+### Features
 
-- **`docs/`**: Contains all source content for all languages.
-- **`*.en.md`**: English language files are identified by the `.en.md` suffix.
-- **`*.de.md`**: German language files are identified by the `.de.md` suffix.
+-   **AI-Powered Content:** Generate a course title, description, and full chapter content from a single topic prompt.
+-   **Multiple AI Providers:** Supports a wide range of AI models to suit your needs:
+    -   **Offline (Local Network):** Use models running on your own machine with **Ollama**.
+    -   **Online (In-Browser):** Use **WebLLM** to run models directly in your browser tab—no server or setup required.
+    -   **Online (Cloud APIs):** Use powerful cloud models from **OpenAI**, **Anthropic**, and **Google** (requires API keys).
+-   **Multi-Language Translation:** Automatically translate your generated course into over 10 languages.
+-   **Downloadable Format:** Packages the entire course into a `.zip` file with all necessary Markdown files and a folder structure compatible with the publishing platform.
+-   **Manual Editing:** Full control to add, remove, and edit chapters and content after generation.
 
-## Getting Started
+### How to Run the Course Creator
 
-To work with this repository on your local machine, you'll need Python installed.
+You can run the course creator tool in two ways:
 
-1.  **Clone the repository:**
-    ```bash
-    git clone https://github.com/florindottudosedotcom/emotions-for-engineers.git
-    cd emotions-for-engineers
-    ```
+1.  **Online (Recommended for WebLLM & Cloud APIs):**
+    -   Access the tool directly from the published GitHub Pages site for this repository. This is the easiest way to get started, especially if you plan to use WebLLM or Cloud API providers.
 
-2.  **Create a virtual environment (recommended):**
-    ```bash
-    python -m venv venv
-    source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
-    ```
+2.  **Locally (Required for Ollama):**
+    -   To use Ollama, you must run the tool from a local web server. We have included convenient scripts to do this for you.
+    -   **On macOS/Linux:**
+        ```bash
+        ./start_course_creator.sh
+        ```
+    -   **On Windows:**
+        ```batch
+        ./start_course_creator.bat
+        ```
+    -   These scripts will start a local server and provide you with a URL (usually `http://localhost:8000/docs/course-creator.html`).
+    -   **Important for Ollama Users:** You may need to configure Ollama to allow requests from the web browser. Please see the official Ollama documentation for instructions on how to manage `OLLAMA_ORIGINS`.
 
-3.  **Install dependencies:**
-    ```bash
-    pip install -r requirements.txt
-    ```
+---
 
-## Local Development
+## Part 2: The Course Publishing Platform
 
-To preview your website as you make changes, start the live-reloading server:
+This repository is also a fully configured MkDocs project for publishing the content you create.
+
+### Features
+
+-   **Markdown-Based:** All content is written in simple Markdown files.
+-   **Multi-Language Support:** Fully configured for multiple languages using a file-suffix convention (e.g., `index.en.md`, `index.de.md`).
+-   **Automated Deployment:** Every push to the `main` branch automatically builds and deploys the latest version of your course website to GitHub Pages.
+-   **Clean Navigation:** A contextual sidebar shows only the chapters for the course you are currently viewing.
+
+### Local Development (Publishing Platform)
+
+To preview your **published course website** as you make changes to the Markdown files, start the MkDocs live-reloading server:
 
 ```bash
+# Make sure you have installed dependencies first: pip install -r requirements.txt
 mkdocs serve
 ```
 
-This will start a local web server, typically at `http://127.0.0.1:8000`. The server will automatically rebuild the site when you save a file.
+This will start a local web server, typically at `http://127.0.0.1:8000`, for previewing your final website. **Note:** This is for viewing the *output*, not for running the creator tool.
 
-## Managing Content
+### Deployment to GitHub Pages
 
-### Adding a New Course
+Deployment is automated via GitHub Actions. For the initial setup in your own fork:
 
-1.  Decide on a short, descriptive name for your course folder (e.g., `new-awesome-course`).
-2.  Create a new directory for the course inside the `docs/` folder (e.g., `docs/new-awesome-course`).
-3.  Add your chapter Markdown (`.md`) files to the course directory, making sure to use the correct language suffix (e.g., `chapter-1.en.md`).
-4.  Add the new course to the navigation in the `mkdocs.yml` file. You will need to add an entry for each language you are supporting.
-
-### Translation Workflow
-
-The system uses file suffixes to manage translations.
-
-1.  To add a translation for a page, create a new file with the same name but the target language's suffix. For example, to translate `course-example/intro.en.md`, you would create `course-example/intro.de.md`.
-2.  The language switcher on the website will automatically link between the translated pages if they share the same base filename.
-
-## Deployment to GitHub Pages
-
-Deployment is fully automated. Simply push your changes to the `main` branch, and the GitHub Actions workflow will build and deploy your site automatically.
-
-### One-Time Setup
-To get your site live, you need to enable GitHub Pages in your repository settings:
-
-1.  Go to your repository on GitHub and click on the **Settings** tab.
-2.  In the left sidebar, under "Code and automation", click on **Pages**.
-3.  Under "Build and deployment", for the **Source**, select **Deploy from a branch**.
-4.  Under "Branch", select `gh-pages` as the source branch and `/ (root)` as the folder.
-5.  Click **Save**.
-
-After a few minutes, your website will be live at: **https://florindottudosedotcom.github.io/emotions-for-engineers/**
+1.  Go to your repository's **Settings** > **Pages**.
+2.  Under "Build and deployment," for the **Source**, select **GitHub Actions**.
+3.  Your website will be live at `https://<your-username>.github.io/<your-repo-name>/`.

--- a/docs/assets/js/course-creator.js
+++ b/docs/assets/js/course-creator.js
@@ -13,7 +13,7 @@ const SESSION_API_KEYS = {
 };
 
 // --- DOM Element variables ---
-let courseForm, chaptersContainer, addChapterBtn, downloadSection, downloadZipLink, aiStatus, courseNameInput, courseDescTextarea, settingsBtn, settingsModal, closeSettingsBtn, apiKeysForm, openAiApiKeyInput, anthropicApiKeyInput, googleApiKeyInput, aiProviderSelect, aiModelSelect, aiModelSelectionGroup, refreshModelsBtn, ollamaStatus, providerConfigFieldset, masterPromptTextarea, numChaptersSelect, generateCourseBtn, webllmIframe;
+let courseForm, chaptersContainer, addChapterBtn, downloadSection, downloadZipLink, aiStatus, courseNameInput, courseDescTextarea, settingsBtn, settingsModal, closeSettingsBtn, apiKeysForm, openAiApiKeyInput, anthropicApiKeyInput, googleApiKeyInput, aiProviderSelect, aiModelSelect, aiModelSelectionGroup, refreshModelsBtn, ollamaStatus, providerConfigFieldset, masterPromptTextarea, numChaptersSelect, generateCourseBtn, webllmIframe, helpBtn, helpModal, closeHelpBtn;
 
 let chapterCount = 0;
 const editorInstances = {}; // Will now store { content, isReady, iframe }
@@ -589,6 +589,17 @@ document.addEventListener('DOMContentLoaded', () => {
     numChaptersSelect = document.getElementById('num-chapters');
     generateCourseBtn = document.getElementById('generate-course-btn');
     webllmIframe = document.getElementById('webllm-iframe');
+    helpBtn = document.getElementById('help-btn');
+    helpModal = document.getElementById('help-modal');
+    closeHelpBtn = document.getElementById('close-help-btn');
+
+    helpBtn.addEventListener('click', () => helpModal.classList.add('visible'));
+    closeHelpBtn.addEventListener('click', () => helpModal.classList.remove('visible'));
+    helpModal.addEventListener('click', (e) => {
+        if (e.target === helpModal) {
+            helpModal.classList.remove('visible');
+        }
+    });
 
     refreshModelsBtn.addEventListener('click', loadOllamaModels);
     generateCourseBtn.addEventListener('click', generateCourse);

--- a/docs/course-creator.html
+++ b/docs/course-creator.html
@@ -10,6 +10,26 @@
 </head>
 <body>
 
+    <div id="help-modal" class="modal-overlay">
+        <div class="modal-content">
+            <h2>How to Use This Tool</h2>
+            <div id="help-content">
+                <ol>
+                    <li><strong>Select AI Provider:</strong> Choose your preferred AI provider. For Ollama, you must be running this tool on a local server. For WebLLM and Cloud providers, the hosted version is fine.</li>
+                    <li><strong>Enter Course Topic:</strong> In the "Master AI Assistant" section, write a prompt for the course you want to create (e.g., "A beginner's guide to Python programming").</li>
+                    <li><strong>Generate Course Outline:</strong> Click "Generate Entire Course". The AI will create a title, description, and a full set of chapter titles and content.</li>
+                    <li><strong>Review and Edit:</strong> Manually edit the course and chapter titles or content as needed. You can also add or remove chapters.</li>
+                    <li><strong>Choose Languages:</strong> Select one or more languages for your course. The content will be translated automatically.</li>
+                    <li><strong>Generate Files:</strong> Click "Generate Course Files" to package everything into a downloadable `.zip` file.</li>
+                </ol>
+                <p>For more detailed instructions, including how to set up local providers, please see the project's <a href="../README.md" target="_blank">README.md</a> file.</p>
+            </div>
+            <div class="input-group margin-top-1-5rem">
+                <button type="button" id="close-help-btn" class="btn btn-danger margin-left-auto">Close</button>
+            </div>
+        </div>
+    </div>
+
     <div id="settings-modal" class="modal-overlay">
         <div class="modal-content">
             <h2>Cloud API Settings</h2>
@@ -35,23 +55,11 @@
     <div class="container">
         <div class="header-container">
             <h1>Universal Course Creator</h1>
+            <button type="button" id="help-btn" class="btn btn-secondary">Help</button>
             <button type="button" id="settings-btn" class="btn btn-secondary">Settings</button>
         </div>
         <div id="ai-status" class="ai-status-initial"></div>
 
-        <div class="instructions">
-            <h3>How to Use This Tool</h3>
-            <ol>
-                <li>Make sure Ollama is running on your computer and you have downloaded a model (e.g., `ollama pull llama3`).</li>
-                <li><b>Ollama Users:</b> If you are running this page from a local file (`file:///...`), you might need to configure Ollama to allow requests from this origin. See the project's `README.md` file for detailed instructions on how to do this.</li>
-                <li>Enter a topic for your course below and select the number of chapters.</li>
-                <li>Click "Generate Course". The AI will populate the course details and chapters for you.</li>
-                <li>Review and edit the generated content as needed.</li>
-                <li>Select the languages you want to translate the course into.</li>
-                <li>Click "Generate Course Files". This will create a .zip file with all the markdown files.</li>
-                <li><strong>Security Note:</strong> When downloading new versions of this tool from the releases page, always verify the checksums of the downloaded assets to ensure they have not been tampered with.</li>
-            </ol>
-        </div>
 
         <fieldset>
             <legend>AI Provider</legend>


### PR DESCRIPTION
This commit significantly overhauls the project's documentation to improve clarity and user experience.

Key changes include:

1.  **README.md Rewrite:**
    -   The README has been rewritten to reflect the project's dual purpose: a course publishing platform and an AI-powered creation tool.
    -   Added a detailed section for the "Universal Course Creator," explaining its features, supported AI providers (Ollama, WebLLM, Cloud), and the distinction between online and offline usage.
    -   Clarified the local development process, explaining how to run the creator tool vs. how to preview the published MkDocs site.

2.  **UI Instructions Refactor:**
    -   The verbose "How to Use" section has been removed from the main body of the course creator.
    -   A new "Help" button has been added to the header.
    -   This button opens a modal containing a concise, user-friendly guide to getting started.
    -   The modal links to the main README.md for more detailed instructions.