### PR TITLE
debug(csp): Temporarily widen CSP for testing

### DIFF
--- a/docs/webllm_iframe.html
+++ b/docs/webllm_iframe.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-eval' blob:; worker-src 'self' blob:; connect-src 'self' https://huggingface.co https://raw.githubusercontent.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-eval' blob:; worker-src 'self' blob:; connect-src 'self' https:;">
     <title>WebLLM Worker</title>
 </head>
 <body>


### PR DESCRIPTION
This commit introduces a temporary and permissive Content Security Policy to debug a persistent model loading issue. The `connect-src` has been changed to `https:`.

This is NOT the final solution and should NOT be merged. This branch is for testing purposes only to identify if the issue is solely related to the `connect-src` domains.