### PR TITLE
fix(webllm): Fix race condition on initial model load

### DIFF
--- a/docs/assets/js/webllm_iframe.js
+++ b/docs/assets/js/webllm_iframe.js
@@ -1,5 +1,8 @@
 import * as webllm from "./webllm.js";
 
+// Signal to the parent window that the iframe's script is loaded and ready to receive messages.
+parent.postMessage({ type: 'webllm-iframe-ready' }, '*');
+
 let webllmEngine;
 let currentModelId;
 


### PR DESCRIPTION
This commit resolves a race condition that occurred on initial page load, preventing the default WebLLM model from loading until the user manually selected a different one.

The issue was caused by the main page sending an initialization command before the WebLLM iframe was ready to receive messages.

The fix implements a handshake mechanism:
1. The iframe now sends a `webllm-iframe-ready` message as soon as it loads.
2. The main page waits for this message before sending any initialization commands, queuing the request if it arrives early.

This ensures that the model initialization is always performed in the correct order.