### PR TITLE
fix(course-creator): Implement dynamic iframe height resizing

### DIFF
--- a/docs/assets/js/cloud_main.js
+++ b/docs/assets/js/cloud_main.js
@@ -53,4 +53,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initial Load
     setTimeout(UI.addChapter, 0);
+    UI.initResizeObserver();
 });

--- a/docs/assets/js/modules/ui.js
+++ b/docs/assets/js/modules/ui.js
@@ -108,6 +108,20 @@ export function initUI(domElements) {
     dom = domElements;
 }
 
+function initResizeObserver() {
+    if (!window.ResizeObserver) {
+        console.warn("ResizeObserver not supported, iframe resizing will not work.");
+        return;
+    }
+
+    const observer = new ResizeObserver(entries => {
+        const height = document.body.scrollHeight;
+        window.parent.postMessage({ type: 'resize-iframe', height: height }, window.location.origin);
+    });
+
+    observer.observe(document.body);
+}
+
 export {
     showSettingsModal,
     hideSettingsModal,
@@ -116,5 +130,6 @@ export {
     addChapter,
     updateAiStatus,
     updateOllamaStatus,
-    editorInstances
+    editorInstances,
+    initResizeObserver
 };

--- a/docs/assets/js/ollama_main.js
+++ b/docs/assets/js/ollama_main.js
@@ -55,4 +55,5 @@ document.addEventListener('DOMContentLoaded', () => {
     API.loadOllamaModels();
     State.loadState();
     setTimeout(UI.addChapter, 0);
+    UI.initResizeObserver();
 });

--- a/docs/assets/js/shell_main.js
+++ b/docs/assets/js/shell_main.js
@@ -41,4 +41,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (helpBtn) helpBtn.addEventListener('click', showHelpModal);
     if (closeHelpBtn) closeHelpBtn.addEventListener('click', hideHelpModal);
+
+    window.addEventListener('message', (event) => {
+        // We only accept messages from our own origin
+        if (event.origin !== window.location.origin) {
+            return;
+        }
+
+        const { type, height } = event.data;
+        if (type === 'resize-iframe' && contentFrame) {
+            contentFrame.style.height = `${height}px`;
+        }
+    });
 });

--- a/docs/assets/js/webllm_main.js
+++ b/docs/assets/js/webllm_main.js
@@ -66,6 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
     API.loadWebLLMModels();
     State.loadState();
     setTimeout(UI.addChapter, 0);
+    UI.initResizeObserver();
 });
 
 window.addEventListener('message', (event) => {


### PR DESCRIPTION
This commit fixes a regression from a previous change where removing the fixed height on the shell container caused the content iframe to collapse to a very small default height.

To fix this, a robust iframe resizing mechanism has been implemented:

1.  **Parent Listener (`shell_main.js`):** The main shell page now listens for `message` events. When it receives a `resize-iframe` message, it dynamically sets the height of the iframe element.

2.  **Child Observer (`ui.js`):** A new `initResizeObserver` function has been added to the UI module. This function runs inside the iframe and uses a `ResizeObserver` to monitor the content's body for any size changes.

3.  **Communication:** When the `ResizeObserver` detects a change in the content's height, it uses `window.parent.postMessage` to send the new `scrollHeight` to the parent shell page, triggering the resize.

4.  **Integration:** The `initResizeObserver` function is now called from `cloud_main.js`, `webllm_main.js`, and `ollama_main.js` to ensure this functionality is active on all tabs.

This ensures the iframe container always adjusts its height to perfectly fit its content, as originally intended.