### PR TITLE
fix(api): Add defensive checks to prevent crash

### DIFF
--- a/docs/assets/js/modules/api.js
+++ b/docs/assets/js/modules/api.js
@@ -14,8 +14,10 @@ function initializeWebLLM(modelId) {
     state.isWebllmReady = false;
     state.currentWebllmModel = '';
     const selectedModelName = state.WEBLLM_MODELS.find(m => m.id === modelId)?.name || modelId;
-    dom.ollamaStatus.textContent = `🔵 Initializing ${selectedModelName}... This may take a moment.`;
-    dom.ollamaStatus.className = 'ollama-status-style ollama-status-info';
+    if (dom.ollamaStatus) {
+        dom.ollamaStatus.textContent = `🔵 Initializing ${selectedModelName}... This may take a moment.`;
+        dom.ollamaStatus.className = 'ollama-status-style ollama-status-info';
+    }
     dom.webllmIframe.contentWindow.postMessage({ type: 'initialize-webllm', modelId: modelId }, '*');
 }
 
@@ -36,8 +38,10 @@ function loadWebLLMModels() {
 }
 
 async function loadOllamaModels() {
-    dom.ollamaStatus.textContent = 'Loading Ollama models...';
-    dom.ollamaStatus.className = 'ollama-status-style';
+    if (dom.ollamaStatus) {
+        dom.ollamaStatus.textContent = 'Loading Ollama models...';
+        dom.ollamaStatus.className = 'ollama-status-style';
+    }
     dom.aiModelSelect.innerHTML = '';
     try {
         const response = await fetch('http://localhost:11434/api/tags');
@@ -46,15 +50,21 @@ async function loadOllamaModels() {
             data.models.forEach(model => {
                 dom.aiModelSelect.add(new Option(model.name, model.name));
             });
-            dom.ollamaStatus.textContent = `✅ Ollama connected. ${data.models.length} model(s) found.`;
-            dom.ollamaStatus.className = 'ollama-status-style ollama-status-ok';
+            if (dom.ollamaStatus) {
+                dom.ollamaStatus.textContent = `✅ Ollama connected. ${data.models.length} model(s) found.`;
+                dom.ollamaStatus.className = 'ollama-status-style ollama-status-ok';
+            }
         } else {
-             dom.ollamaStatus.textContent = `⚠️ Ollama is running but no models found.`;
-             dom.ollamaStatus.className = 'ollama-status-style';
+             if (dom.ollamaStatus) {
+                dom.ollamaStatus.textContent = `⚠️ Ollama is running but no models found.`;
+                dom.ollamaStatus.className = 'ollama-status-style';
+             }
         }
     } catch(err) {
-         dom.ollamaStatus.textContent = `❌ Could not connect to Ollama.`;
-         dom.ollamaStatus.className = 'ollama-status-style ollama-status-error';
+         if (dom.ollamaStatus) {
+            dom.ollamaStatus.textContent = `❌ Could not connect to Ollama.`;
+            dom.ollamaStatus.className = 'ollama-status-style ollama-status-error';
+         }
     }
 }
 
@@ -62,27 +72,33 @@ function handleProviderChange() {
     const selectedProvider = dom.aiProviderSelect.value;
     state.AI_PROVIDER = selectedProvider;
 
-    dom.aiModelSelectionGroup.style.display = 'none';
-    dom.refreshModelsBtn.style.display = 'none';
-    dom.ollamaStatus.textContent = '';
-    dom.ollamaStatus.className = 'ollama-status-style';
+    if (dom.aiModelSelectionGroup) dom.aiModelSelectionGroup.style.display = 'none';
+    if (dom.refreshModelsBtn) dom.refreshModelsBtn.style.display = 'none';
+    if (dom.ollamaStatus) {
+        dom.ollamaStatus.textContent = '';
+        dom.ollamaStatus.className = 'ollama-status-style';
+    }
 
     if (selectedProvider === 'ollama') {
-        dom.aiModelSelectionGroup.style.display = 'flex';
-        dom.refreshModelsBtn.style.display = 'block';
+        if (dom.aiModelSelectionGroup) dom.aiModelSelectionGroup.style.display = 'flex';
+        if (dom.refreshModelsBtn) dom.refreshModelsBtn.style.display = 'block';
         loadOllamaModels();
     } else if (selectedProvider === 'webllm') {
-        dom.aiModelSelectionGroup.style.display = 'flex';
-        dom.refreshModelsBtn.style.display = 'none';
+        if (dom.aiModelSelectionGroup) dom.aiModelSelectionGroup.style.display = 'flex';
+        if (dom.refreshModelsBtn) dom.refreshModelsBtn.style.display = 'none';
         loadWebLLMModels();
     } else {
-         dom.ollamaStatus.textContent = `✅ Ready to use ${selectedProvider}.`;
-         dom.ollamaStatus.className = 'ollama-status-style ollama-status-ok';
+        if (dom.ollamaStatus) {
+            dom.ollamaStatus.textContent = `✅ Ready to use ${selectedProvider}.`;
+            dom.ollamaStatus.className = 'ollama-status-style ollama-status-ok';
+        }
     }
 }
 
 async function updateAvailableProviders() {
-    dom.ollamaStatus.textContent = 'Detecting available AI providers...';
+    if (dom.ollamaStatus) {
+        dom.ollamaStatus.textContent = 'Detecting available AI providers...';
+    }
     const selectedProviderBeforeUpdate = dom.aiProviderSelect.value;
     dom.aiProviderSelect.innerHTML = '';
 


### PR DESCRIPTION
This commit fixes a TypeError that occurred when submitting API keys on the "Cloud AI" tab.

The error `Cannot set properties of undefined (setting 'textContent')` was caused by the shared `api.js` module attempting to update the `ollamaStatus` DOM element. This element does not exist on the `cloud_creator.html` page, causing `dom.ollamaStatus` to be `undefined` and leading to a crash.

The fix makes the `api.js` module more robust by adding defensive checks around all manipulations of DOM elements that may not be present on every page (such as `dom.ollamaStatus`, `dom.aiModelSelectionGroup`, and `dom.refreshModelsBtn`). This ensures the code does not crash if an element is not found in the current context.