### PR TITLE
fix(webllm): Resolve race condition during initialization

### DIFF
--- a/docs/assets/js/webllm_iframe.js
+++ b/docs/assets/js/webllm_iframe.js
@@ -1,7 +1,9 @@
 import * as webllm from "./webllm.js";
 
-// Signal to the parent window that the iframe's script is loaded and ready to receive messages.
-parent.postMessage({ type: 'webllm-iframe-ready' }, '*');
+document.addEventListener('DOMContentLoaded', () => {
+    // Signal to the parent window that the iframe is fully loaded and ready.
+    parent.postMessage({ type: 'webllm-iframe-ready' }, '*');
+});
 
 let webllmEngine;
 let currentModelId;


### PR DESCRIPTION
This commit fixes a race condition that prevented the WebLLM model from initializing correctly.

Previously, the `webllm_iframe.js` script sent a `webllm-iframe-ready` message to its parent window immediately upon script execution. This message was often sent before the parent page (`webllm_creator.html`) had finished loading and attached its `message` event listener, causing the "ready" signal to be lost.

The fix is to wrap the `postMessage` call in `webllm_iframe.js` within a `DOMContentLoaded` event listener. This ensures the message is only sent after the iframe's own DOM is fully loaded, giving the parent page sufficient time to set up its listener and correctly receive the signal. This resolves the timing issue and allows the WebLLM engine to initialize as expected.