### PR TITLE
fix(course): Prevent crash when parsing course details

### DIFF
--- a/docs/assets/js/modules/course.js
+++ b/docs/assets/js/modules/course.js
@@ -52,7 +52,10 @@ function parseAndPopulateCourseDetails(textResponse) {
         dom.courseNameInput.value = courseTitle;
         dom.courseDescTextarea.value = courseDescription;
 
-        dom.chaptersContainer.innerHTML = '';
+        // Clear existing chapter tabs and content
+        if (dom.chapterTabsContainer) dom.chapterTabsContainer.innerHTML = '';
+        if (dom.chapterContentContainer) dom.chapterContentContainer.innerHTML = '';
+
         Object.keys(ui.editorInstances).forEach(key => delete ui.editorInstances[key]);
         // chapterCount needs to be managed by the UI module
         // For now, this is a dependency issue.


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred when generating a course from the "Cloud AI" tab.

The error `Cannot set properties of undefined (setting 'innerHTML')` was caused by the `parseAndPopulateCourseDetails` function in `course.js`. This function was attempting to clear chapter content by accessing `dom.chaptersContainer`, which was an outdated reference from a previous refactoring. The correct elements are now `dom.chapterTabsContainer` and `dom.chapterContentContainer`.

The fix replaces the incorrect line with the correct references and adds defensive `if` checks to ensure the code does not crash if these elements are not present. This resolves the final known bug in the course creator flow.