### PR TITLE
fix(course): Reset chapter counter to fix content population

### DIFF
--- a/docs/assets/js/modules/course.js
+++ b/docs/assets/js/modules/course.js
@@ -57,8 +57,7 @@ function parseAndPopulateCourseDetails(textResponse) {
         if (dom.chapterContentContainer) dom.chapterContentContainer.innerHTML = '';
 
         Object.keys(ui.editorInstances).forEach(key => delete ui.editorInstances[key]);
-        // chapterCount needs to be managed by the UI module
-        // For now, this is a dependency issue.
+        ui.resetChapterCount();
 
         ui.updateAiStatus("✅ Course details populated. Generating chapters...");
         generateChaptersInLoop();

--- a/docs/assets/js/modules/ui.js
+++ b/docs/assets/js/modules/ui.js
@@ -108,6 +108,10 @@ export function initUI(domElements) {
     dom = domElements;
 }
 
+function resetChapterCount() {
+    chapterCount = 0;
+}
+
 export {
     showSettingsModal,
     hideSettingsModal,
@@ -116,5 +120,6 @@ export {
     addChapter,
     updateAiStatus,
     updateOllamaStatus,
-    editorInstances
+    editorInstances,
+    resetChapterCount
 };


### PR DESCRIPTION
This commit fixes a critical bug where generated chapter content was not being populated into the correct chapter tabs.

The root cause was that the `chapterCount` variable in `ui.js` was not being reset when a new course was generated. This caused a desynchronization between the chapter generation loop counter (e.g., 1, 2, 3) and the chapter creation counter (e.g., 2, 3, 4), leading to the code attempting to populate content into non-existent or incorrect DOM elements.

The fix introduces a `resetChapterCount()` function in `ui.js` and calls it from `course.js` before a new set of chapters is generated. This ensures the chapter IDs are always in sync, allowing the content to be populated correctly.