### PR TITLE
fix(webllm): Implement robust handshake to fix race condition

### DIFF
--- a/docs/assets/js/webllm_main.js
+++ b/docs/assets/js/webllm_main.js
@@ -64,7 +64,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initial Load
     State.loadState();
-    API.loadWebLLMModels();
 });
 
 window.addEventListener('message', (event) => {
@@ -73,6 +72,7 @@ window.addEventListener('message', (event) => {
 
         if (type === 'webllm-iframe-ready') {
             appState.isWebllmIframeReady = true;
+            API.loadWebLLMModels(); // Moved from DOMContentLoaded
             if (appState.pendingWebllmModelId) {
                 API.initializeWebLLM(appState.pendingWebllmModelId);
                 appState.pendingWebllmModelId = null;


### PR DESCRIPTION
This commit provides a definitive fix for a persistent race condition that prevented the WebLLM model from initializing on the first tab load.

The previous fix, which delayed the "ready" message from the iframe, was not sufficient. The root cause was that the parent page (`webllm_main.js`) was attempting to load the model before it had received the "ready" signal from its child iframe.

This commit resolves the issue by implementing a proper handshake:

1.  The `API.loadWebLLMModels()` call is removed from the `DOMContentLoaded` listener in `webllm_main.js`.
2.  This call is moved into the `message` event listener, specifically within the `if (type === 'webllm-iframe-ready')` block.

This guarantees that the model loading process only begins *after* the WebLLM iframe has loaded and explicitly signaled that it is ready to be used. This eliminates the race condition entirely.