### PR TITLE
fix(api): Correct AI provider detection logic

### DIFF
--- a/docs/assets/js/modules/api.js
+++ b/docs/assets/js/modules/api.js
@@ -170,7 +170,16 @@ function saveApiKeys(e) {
 }
 
 async function generateAIText(systemPrompt) {
-    const provider = dom.aiProviderSelect ? dom.aiProviderSelect.value : 'openai'; // Default to openai if no selector
+    let provider = state.AI_PROVIDER;
+
+    if (provider === 'cloud') {
+        // Auto-detect which cloud provider to use based on available keys
+        if (state.SESSION_API_KEYS.openai) provider = 'openai';
+        else if (state.SESSION_API_KEYS.anthropic) provider = 'anthropic';
+        else if (state.SESSION_API_KEYS.google) provider = 'google';
+        else throw new Error("No Cloud API key has been provided. Please add one in Settings.");
+    }
+
     let endpoint = '';
     let headers = { 'Content-Type': 'application/json' };
     let body = {};


### PR DESCRIPTION
This commit fixes a bug that caused a crash when generating a course on the WebLLM tab. The error was due to flawed logic for determining the current AI provider.

The `generateAIText` function was incorrectly defaulting to 'openai' if a provider selection dropdown was not found. This caused it to try and access OpenAI API keys even when on the WebLLM or Ollama tabs, leading to a crash if those keys weren't present.

The fix refactors the provider detection logic:
1.  The function now correctly uses `state.AI_PROVIDER`, which is explicitly set for each tab, to determine the provider.
2.  It adds a new block to handle the generic 'cloud' provider case by intelligently selecting the first available concrete cloud provider (OpenAI, Anthropic, or Google) based on the saved API keys.

This makes the provider detection robust and corrects the execution flow for all tabs.