### PR TITLE
fix(state): Prevent overwriting state with empty values

### DIFF
--- a/docs/assets/js/modules/state.js
+++ b/docs/assets/js/modules/state.js
@@ -5,6 +5,12 @@ let ui = {};
 const LOCAL_STORAGE_KEY = "courseCreatorState";
 
 function saveState() {
+    // Do not save if the course name is empty, as this is a proxy for an uninitialized or invalid state.
+    if (!dom.courseNameInput || !dom.courseNameInput.value) {
+        console.log("Save state aborted: Course name is empty.");
+        return;
+    }
+
     const chapters = [];
     // The chapter content divs are now the source of truth for order and ID
     dom.chapterContentContainer.querySelectorAll('.chapter-content').forEach(contentDiv => {


### PR DESCRIPTION
This commit fixes a persistent bug where the course state was being forgotten when switching between tabs.

The root cause was likely an unintended call to `saveState()` at a point where the form was empty, causing the valid state in `localStorage` to be overwritten with a blank object.

While the exact trigger for the incorrect save was hard to pinpoint, this fix makes the `saveState` function in `state.js` more robust and prevents the negative outcome. A guard has been added at the beginning of the function to check if the course name is empty. If it is, the function returns immediately, effectively refusing to save an invalid or uninitialized state.

This defensive programming approach ensures that a valid, saved state cannot be accidentally wiped out, resolving the "forgotten state" issue.