### PR TITLE
Refactor course creator to a launcher page

### DIFF
--- a/docs/assets/css/course-creator.css
+++ b/docs/assets/css/course-creator.css
@@ -67,3 +67,65 @@ input[type="checkbox"] { margin-right: 0.5rem; }
 .ollama-status-info {
     color: blue;
 }
+
+/* New Launcher Page Styles */
+.main-container {
+    max-width: 900px;
+    margin: 2rem auto;
+    background-color: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.launcher-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.launcher-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    border-radius: 8px;
+    text-decoration: none;
+    color: #fff;
+    font-size: 1.25rem;
+    font-weight: bold;
+    text-align: center;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.launcher-btn:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 15px rgba(0,0,0,0.2);
+}
+
+.launcher-btn.cloud { background-color: #3498db; }
+.launcher-btn.webllm { background-color: #2ecc71; }
+.launcher-btn.ollama { background-color: #e67e22; }
+
+.launcher-btn.disabled {
+    background-color: #bdc3c7;
+    cursor: not-allowed;
+    pointer-events: none;
+    transform: none;
+    box-shadow: none;
+}
+
+.launcher-btn .icon {
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.help-section {
+    margin-top: 2rem;
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 1.5rem;
+}

--- a/docs/course-creator.html
+++ b/docs/course-creator.html
@@ -5,108 +5,59 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Universal Course Creator</title>
     <link rel="stylesheet" href="./assets/css/course-creator.css" />
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            background-color: #f9f9f9;
-        }
-        .main-container {
-            max-width: 1200px;
-            margin: 2rem auto;
-            background-color: #fff;
-            padding: 2rem;
-            border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        }
-        .shell-container {
-            display: flex;
-            flex-direction: column;
-            height: 90vh; /* Adjust height as needed */
-            /* border: 1px solid #ccc; */ /* Border removed */
-            border-radius: 4px;
-        }
-        .tab-nav {
-            flex-shrink: 0;
-            display: flex;
-            background-color: #f1f1f1;
-            border-bottom: 1px solid #ccc;
-            width: 100%; /* Ensure tab nav takes full width */
-        }
-        .tab-nav button {
-            background-color: inherit;
-            border: none;
-            outline: none;
-            cursor: pointer;
-            padding: 14px 16px;
-            transition: 0.3s;
-            font-size: 16px;
-        }
-        .tab-nav button:hover {
-            background-color: #ddd;
-        }
-        .tab-nav button.active {
-            background-color: #ccc;
-        }
-        .content-frame {
-            flex-grow: 1;
-            border: none;
-        }
-        .header-container {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1rem;
-        }
-    </style>
 </head>
 <body>
     <div class="main-container">
         <div class="header-container">
             <h1>Universal Course Creator</h1>
-            <button type="button" id="help-btn" class="btn btn-secondary">Help</button>
         </div>
 
-        <div class="shell-container">
-            <div class="tab-nav">
-                <button class="tab-link active" data-src="cloud_creator.html">☁️ Cloud AI</button>
-                <button class="tab-link" data-src="webllm_creator.html">🧠 WebLLM (In-Browser)</button>
-                <button class="tab-link" id="ollama-tab" data-src="ollama_creator.html">🖥️ Ollama (Local)</button>
-            </div>
-            <iframe id="content-frame" class="content-frame" src="cloud_creator.html"></iframe>
+        <div class="launcher-container">
+            <a href="cloud_creator.html" target="_blank" class="launcher-btn cloud">
+                <div class="icon">☁️</div>
+                <div>Cloud AI</div>
+            </a>
+            <a href="webllm_creator.html" target="_blank" class="launcher-btn webllm">
+                <div class="icon">🧠</div>
+                <div>WebLLM (In-Browser)</div>
+            </a>
+            <a href="ollama_creator.html" target="_blank" class="launcher-btn ollama" id="ollama-btn">
+                <div class="icon">🖥️</div>
+                <div>Ollama (Local)</div>
+            </a>
         </div>
-    </div>
 
-    <!-- Help Modal -->
-    <div id="help-modal" class="modal-overlay">
-        <div class="modal-content">
+        <div id="help-section" class="help-section">
             <h2>How to Use This Tool</h2>
-            <div id="help-content">
-                <h4>Welcome to the Universal Course Creator!</h4>
-                <p>This tool helps you generate entire courses using various AI models.</p>
-                <h5><strong>How to Use:</strong></h5>
-                <ol>
-                    <li><strong>Select an AI Provider Tab:</strong>
-                        <ul>
-                            <li>☁️ <strong>Cloud AI:</strong> Use powerful models from OpenAI, Anthropic, and Google. You'll need to provide your own API keys in the 'Settings' menu.</li>
-                            <li>🧠 <strong>WebLLM:</strong> Run a language model directly in your browser. No server or keys needed, but it may be slower.</li>
-                            <li>🖥️ <strong>Ollama (Local):</strong> Connect to a running Ollama instance on your local machine to use your own models.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Enter a Course Prompt:</strong> In the 'Master AI Assistant' section, describe the course you want to create. Be as specific as possible!</li>
-                    <li><strong>Generate Course:</strong> Click "Generate Entire Course". The AI will first generate a title and description, then proceed to generate content for each chapter.</li>
-                    <li><strong>Review and Edit:</strong> Once generated, you can review and edit the content of each chapter in the editor.</li>
-                    <li><strong>Download:</strong> When you're happy with the course, click "Generate Course Files" at the bottom to download a .zip file containing all the course materials.</li>
-                </ol>
-            </div>
-            <div class="input-group margin-top-1-5rem">
-                <button type="button" id="close-help-btn" class="btn btn-danger margin-left-auto">Close</button>
-            </div>
+            <h4>Welcome to the Universal Course Creator!</h4>
+            <p>This tool helps you generate entire courses using various AI models.</p>
+            <h5><strong>How to Use:</strong></h5>
+            <ol>
+                <li><strong>Select an AI Provider:</strong>
+                    <ul>
+                        <li>☁️ <strong>Cloud AI:</strong> Use powerful models from OpenAI, Anthropic, and Google. You'll need to provide your own API keys in the 'Settings' menu of the Cloud AI page.</li>
+                        <li>🧠 <strong>WebLLM:</strong> Run a language model directly in your browser. No server or keys needed, but it may be slower.</li>
+                        <li>🖥️ <strong>Ollama (Local):</strong> Connect to a running Ollama instance on your local machine to use your own models.</li>
+                    </ul>
+                </li>
+                <li><strong>Enter a Course Prompt:</strong> In the 'Master AI Assistant' section of your chosen creator page, describe the course you want to create. Be as specific as possible!</li>
+                <li><strong>Generate Course:</strong> Click "Generate Entire Course". The AI will first generate a title and description, then proceed to generate content for each chapter.</li>
+                <li><strong>Review and Edit:</strong> Once generated, you can review and edit the content of each chapter in the editor.</li>
+                <li><strong>Download:</strong> When you're happy with the course, click "Generate Course Files" at the bottom to download a .zip file containing all the course materials.</li>
+            </ol>
         </div>
     </div>
 
-    <script src="./assets/js/shell_main.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const ollamaBtn = document.getElementById('ollama-btn');
+            const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1' || window.location.protocol === 'file:';
 
+            if (!isLocal) {
+                ollamaBtn.classList.add('disabled');
+                ollamaBtn.title = "Ollama is only available when running on localhost.";
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This commit refactors the main `course-creator.html` page from a tabbed shell interface to a modern launcher page.

Key changes:
- Replaced the `iframe`-based tabbed navigation with three large, styled buttons that link to the respective creator pages.
- Each button (`Cloud AI`, `WebLLM`, `Ollama`) now opens its corresponding page in a new browser tab (`target="_blank"`).
- The "Ollama" button is now disabled via JavaScript if the page is not accessed from `localhost`, `127.0.0.1`, or a `file://` URL, as requested.
- Moved the help content from a modal directly onto the main launcher page for easier access.
- Centralized the new styles for the launcher buttons and help section into `docs/assets/css/course-creator.css`.